### PR TITLE
Text weight: Text item typography sub tool

### DIFF
--- a/application/configs/environment.php
+++ b/application/configs/environment.php
@@ -9,8 +9,8 @@
 * Environment setting for application.ini, valid options are 
 * production, development, testing or staging
 */
-$environment = 'production';
-//$environment = 'development';
+//$environment = 'production';
+$environment = 'development';
 
 /**
 * Version number and version release date

--- a/application/configs/environment.php
+++ b/application/configs/environment.php
@@ -9,8 +9,8 @@
 * Environment setting for application.ini, valid options are 
 * production, development, testing or staging
 */
-//$environment = 'production';
-$environment = 'development';
+$environment = 'production';
+//$environment = 'development';
 
 /**
 * Version number and version release date

--- a/application/modules/content/Bootstrap.php
+++ b/application/modules/content/Bootstrap.php
@@ -16,5 +16,7 @@ class Content_Bootstrap extends Zend_Application_Module_Bootstrap
 
         define('DEFAULT_FONT_FAMILY_FOR_MODULE',
             $model_settings->definedFontFamilyId('content', $dlayer_session->siteId()));
+
+        define('DEFAULT_TEXT_WEIGHT_FOR_MODULE', 1);
     }
 }

--- a/application/modules/content/Bootstrap.php
+++ b/application/modules/content/Bootstrap.php
@@ -14,9 +14,11 @@ class Content_Bootstrap extends Zend_Application_Module_Bootstrap
         $dlayer_session = new Dlayer_Session();
         $model_settings = new Dlayer_Model_Settings();
 
-        define('DEFAULT_FONT_FAMILY_FOR_MODULE',
-            $model_settings->definedFontFamilyId('content', $dlayer_session->siteId()));
+        $font_and_text_settings = $model_settings->definedFontAndTextSettings('content', $dlayer_session->siteId());
 
-        define('DEFAULT_TEXT_WEIGHT_FOR_MODULE', 1);
+        if ($font_and_text_settings !== false) {
+            define('DEFAULT_FONT_FAMILY_FOR_MODULE', intval($font_and_text_settings['font_family_id']));
+            define('DEFAULT_TEXT_WEIGHT_FOR_MODULE', intval($font_and_text_settings['text_weight_id']));
+        }
     }
 }

--- a/library/Dlayer/DesignerTool/ContentManager/Text/SubTool/Typography/Form.php
+++ b/library/Dlayer/DesignerTool/ContentManager/Text/SubTool/Typography/Form.php
@@ -68,5 +68,21 @@ class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Form extends Dl
         }
 
         $this->elements['font_family_id'] = $font_family;
+
+        $text_weight = new Zend_Form_Element_Select('text_weight_id');
+        $text_weight->setLabel('Text weight');
+        $text_weight->setDescription('Choose the text weight, defaults to the the text weight selected in settings');
+        if ($this->element_data['text_weights'] !== false) {
+            $text_weight->setMultiOptions($this->element_data['text_weights']);
+        }
+        $text_weight->setAttribs(array('class' => 'form-control input-sm'));
+        $text_weight->setBelongsTo('params');
+        if ($this->data['text_weight_id'] !== false) {
+            $text_weight->setValue($this->data['text_weight_id']);
+        } else {
+            $text_weight->setValue(DEFAULT_TEXT_WEIGHT_FOR_MODULE);
+        }
+
+        $this->elements['text_weight_id'] = $text_weight;
     }
 }

--- a/library/Dlayer/DesignerTool/ContentManager/Text/SubTool/Typography/Model.php
+++ b/library/Dlayer/DesignerTool/ContentManager/Text/SubTool/Typography/Model.php
@@ -10,23 +10,28 @@
 class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Model extends Zend_Db_Table_Abstract
 {
     /**
-     * Fetch the font family for a content item
+     * Fetch the font and text values for the current content item
      *
      * @param integer $site_id
      * @param integer $page_id
      * @param integer $id
      *
-     * @return string|false
+     * @return array|false
      */
-    public function fontFamily($site_id, $page_id, $id)
+    public function fontAndTextValues($site_id, $page_id, $id)
     {
-        $sql = "SELECT uspscit.font_family_id  
-                FROM user_site_page_styling_content_item_typography uspscit 
-                JOIN designer_css_font_family dcff ON
-                    uspscit.font_family_id = dcff.id
-                WHERE uspscit.site_id = :site_id 
-                AND uspscit.page_id = :page_id 
-                AND uspscit.content_id = :content_id 
+        $sql = "SELECT 
+                    `uspscit`.`font_family_id`,
+                    `uspscit`.`text_weight_id`
+                FROM 
+                    `user_site_page_styling_content_item_typography` `uspscit` 
+                JOIN 
+                    `designer_css_font_family` `dcff` ON
+                        `uspscit`.`font_family_id` = `dcff`.`id`
+                WHERE 
+                    `uspscit`.`site_id` = :site_id AND 
+                    `uspscit`.`page_id` = :page_id AND 
+                    `uspscit`.`content_id` = :content_id 
                 LIMIT 1";
         $stmt = $this->_db->prepare($sql);
         $stmt->bindValue(':site_id', $site_id);
@@ -35,8 +40,12 @@ class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Model extends Z
         $stmt->execute();
 
         $result = $stmt->fetch();
+
         if ($result !== false) {
-            return intval($result['font_family_id']);
+            return array(
+                'font_family_id' => ($result['font_family_id'] === null) ? null: intval($result['font_family_id']),
+                'text_weight_id' => ($result['text_weight_id'] === null) ? null: intval($result['text_weight_id'])
+            );
         } else {
             return false;
         }

--- a/library/Dlayer/DesignerTool/ContentManager/Text/SubTool/Typography/Model.php
+++ b/library/Dlayer/DesignerTool/ContentManager/Text/SubTool/Typography/Model.php
@@ -94,10 +94,20 @@ class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Model extends Z
      */
     public function addFontFamily($site_id, $page_id, $id, $font_family_id)
     {
-        $sql = "INSERT INTO user_site_page_styling_content_item_typography 
-                (site_id, page_id, content_id, font_family_id) 
+        $sql = "INSERT INTO `user_site_page_styling_content_item_typography` 
+                (
+                    `site_id`, 
+                    `page_id`, 
+                    `content_id`, 
+                    `font_family_id`
+                ) 
                 VALUES 
-                (:site_id, :page_id, :content_id, :font_family_id)";
+                (
+                    :site_id, 
+                    :page_id, 
+                    :content_id, 
+                    :font_family_id
+                )";
         $stmt = $this->_db->prepare($sql);
         $stmt->bindValue(':site_id', $site_id);
         $stmt->bindValue(':page_id', $page_id);
@@ -120,7 +130,7 @@ class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Model extends Z
         if (intval($font_family_id) !== DEFAULT_FONT_FAMILY_FOR_MODULE) {
             return $this->updateFontFamily($id, $font_family_id);
         } else {
-            return $this->deleteFontFamily($id);
+            return $this->clearFontFamily($id);
         }
     }
 
@@ -134,9 +144,12 @@ class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Model extends Z
      */
     protected function updateFontFamily($id, $font_family_id)
     {
-        $sql = "UPDATE user_site_page_styling_content_item_typography 
-                SET font_family_id = :font_family_id  
-                WHERE id = :id 
+        $sql = "UPDATE 
+                    `user_site_page_styling_content_item_typography` 
+                SET 
+                    `font_family_id` = :font_family_id  
+                WHERE
+                    `id` = :id 
                 LIMIT 1";
         $stmt = $this->_db->prepare($sql);
         $stmt->bindValue(':id', $id);
@@ -151,10 +164,13 @@ class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Model extends Z
      * @param integer $id
      * @return boolean
      */
-    protected function deleteFontFamily($id)
+    protected function clearFontFamily($id)
     {
-        $sql = "DELETE FROM user_site_page_styling_content_item_typography 
-                WHERE id = :id 
+        $sql = "UPDATE `user_site_page_styling_content_item_typography` 
+                SET 
+                    'font_family_id' = NULL
+                WHERE 
+                    `id` = :id 
                 LIMIT 1";
         $stmt = $this->_db->prepare($sql);
         $stmt->bindValue(':id', $id);
@@ -170,12 +186,41 @@ class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Model extends Z
      */
     public function fontFamilyIdValid($font_family_id)
     {
-        $sql = "SELECT id 
-                FROM designer_css_font_family 
-                WHERE id = :id 
+        $sql = "SELECT 
+                    `id` 
+                FROM 
+                    `designer_css_font_family` 
+                WHERE 
+                    `id` = :id 
                 LIMIT 1";
         $stmt = $this->_db->prepare($sql);
         $stmt->bindValue(':id', $font_family_id);
+        $stmt->execute();
+
+        if ($stmt->fetch() !== false) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Text weight valid
+     *
+     * @param integer $text_weight_id
+     * @return boolean
+     */
+    public function textWeightIdValid($text_weight_id)
+    {
+        $sql = "SELECT 
+                    `id` 
+                FROM 
+                    `designer_css_text_weight` 
+                WHERE 
+                     `id` = :id 
+                LIMIT 1";
+        $stmt = $this->_db->prepare($sql);
+        $stmt->bindValue(':id', $text_weight_id, PDO::PARAM_INT);
         $stmt->execute();
 
         if ($stmt->fetch() !== false) {
@@ -192,9 +237,13 @@ class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Model extends Z
      */
     public function fontFamiliesForSelect()
     {
-        $sql = "SELECT id, `name`   
-                FROM designer_css_font_family 
-                ORDER BY `name` ASC";
+        $sql = "SELECT 
+                    `id`, 
+                    `name`   
+                FROM 
+                    `designer_css_font_family` 
+                ORDER BY 
+                    `name` ASC";
         $stmt = $this->_db->prepare($sql);
         $stmt->execute();
 
@@ -218,9 +267,13 @@ class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Model extends Z
      */
     public function textWeightsForSelect()
     {
-        $sql = "SELECT `id`, `name` 
-                FROM `designer_css_text_weight` 
-                ORDER BY `sort_order` ASC";
+        $sql = "SELECT 
+                    `id`, 
+                    `name` 
+                FROM 
+                    `designer_css_text_weight` 
+                ORDER BY 
+                    `sort_order` ASC";
         $stmt = $this->_db->prepare($sql);
         $stmt->execute();
 
@@ -244,8 +297,11 @@ class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Model extends Z
      */
     public function fontFamiliesForPreview()
     {
-        $sql = "SELECT `id`, `css`   
-                FROM `designer_css_font_family`";
+        $sql = "SELECT 
+                    `id`, 
+                    `css`   
+                FROM 
+                    `designer_css_font_family`";
         $stmt = $this->_db->prepare($sql);
         $stmt->execute();
 
@@ -269,8 +325,11 @@ class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Model extends Z
      */
     public function textWeightsForPreview()
     {
-        $sql = "SELECT `id`, `css`
-                FROM `designer_css_text_weight`";
+        $sql = "SELECT 
+                    `id`, 
+                    `css`
+                FROM 
+                    `designer_css_text_weight`";
         $stmt = $this->_db->prepare($sql);
         $stmt->execute();
 

--- a/library/Dlayer/DesignerTool/ContentManager/Text/SubTool/Typography/Model.php
+++ b/library/Dlayer/DesignerTool/ContentManager/Text/SubTool/Typography/Model.php
@@ -203,14 +203,40 @@ class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Model extends Z
     }
 
     /**
+     * Fetch the text weights support by Dlayer for the select
+     *
+     * @return array|false
+     */
+    public function textWeightsForSelect()
+    {
+        $sql = "SELECT `id`, `name` 
+                FROM `designer_css_text_weight` 
+                ORDER BY `sort_order` ASC";
+        $stmt = $this->_db->prepare($sql);
+        $stmt->execute();
+
+        $text_weights = array();
+
+        foreach ($stmt->fetchAll() as $row) {
+            $text_weights[intval($row['id'])] = $row['name'];
+        }
+
+        if (count($text_weights) > 0) {
+            return $text_weights;
+        } else {
+            return false;
+        }
+    }
+
+    /**
      * Fetch the font families supported by Dlayer for the preview
      *
      * @return array|false
      */
     public function fontFamiliesForPreview()
     {
-        $sql = "SELECT id, `css`   
-                FROM designer_css_font_family";
+        $sql = "SELECT `id`, `css`   
+                FROM `designer_css_font_family`";
         $stmt = $this->_db->prepare($sql);
         $stmt->execute();
 
@@ -222,6 +248,31 @@ class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Model extends Z
 
         if (count($font_families) > 0) {
             return $font_families;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Fetch the font weights supported by Dlayer for preview
+     *
+     * @return array|false
+     */
+    public function textWeightsForPreview()
+    {
+        $sql = "SELECT `id`, `css`
+                FROM `designer_css_text_weight`";
+        $stmt = $this->_db->prepare($sql);
+        $stmt->execute();
+
+        $text_weights = array();
+
+        foreach ($stmt->fetchAll() as $row) {
+            $text_weights[intval($row['id'])] = $row['css'];
+        }
+
+        if (count($text_weights) > 0) {
+            return $text_weights;
         } else {
             return false;
         }

--- a/library/Dlayer/DesignerTool/ContentManager/Text/SubTool/Typography/Model.php
+++ b/library/Dlayer/DesignerTool/ContentManager/Text/SubTool/Typography/Model.php
@@ -252,7 +252,7 @@ class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Model extends Z
     {
         $sql = "UPDATE `user_site_page_styling_content_item_typography` 
                 SET 
-                    'font_family_id' = NULL
+                    `font_family_id` = NULL
                 WHERE 
                     `id` = :id 
                 LIMIT 1";
@@ -272,7 +272,7 @@ class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Model extends Z
     {
         $sql = "UPDATE `user_site_page_styling_content_item_typography` 
                 SET 
-                    'text_weight_id' = NULL
+                    `text_weight_id` = NULL
                 WHERE 
                     `id` = :id 
                 LIMIT 1";

--- a/library/Dlayer/DesignerTool/ContentManager/Text/SubTool/Typography/Ribbon.php
+++ b/library/Dlayer/DesignerTool/ContentManager/Text/SubTool/Typography/Ribbon.php
@@ -60,13 +60,12 @@ class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Ribbon extends 
                 );
 
                 if ($font_and_text_values !== false) {
-
-                    if($font_and_text_values['text_weight_id'] !== null) {
-                        $this->content_data['text_weight_id'];
+                    if ($font_and_text_values['text_weight_id'] !== null) {
+                        $this->content_data['text_weight_id'] = $font_and_text_values['text_weight_id'];
                     }
 
-                    if($font_and_text_values['font_family_id'] !== null) {
-                        $this->content_data['font_family_id'];
+                    if ($font_and_text_values['font_family_id'] !== null) {
+                        $this->content_data['font_family_id'] = $font_and_text_values['font_family_id'];
                     }
                 }
             }

--- a/library/Dlayer/DesignerTool/ContentManager/Text/SubTool/Typography/Ribbon.php
+++ b/library/Dlayer/DesignerTool/ContentManager/Text/SubTool/Typography/Ribbon.php
@@ -47,18 +47,27 @@ class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Ribbon extends 
         if ($this->content_fetched === false) {
             $this->content_data = array(
                 'font_family_id' => false,
+                'text_weight_id' => false
             );
 
             if ($this->tool['content_id'] !== null) {
                 $model = new Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Model();
-                $font_family_id = $model->fontFamily(
+
+                $font_and_text_values = $model->fontAndTextValues(
                     $this->tool['site_id'],
                     $this->tool['page_id'],
                     $this->tool['content_id']
                 );
 
-                if ($font_family_id !== false) {
-                    $this->content_data['font_family_id'] = $font_family_id;
+                if ($font_and_text_values !== false) {
+
+                    if($font_and_text_values['text_weight_id'] !== null) {
+                        $this->content_data['text_weight_id'];
+                    }
+
+                    if($font_and_text_values['font_family_id'] !== null) {
+                        $this->content_data['font_family_id'];
+                    }
                 }
             }
 

--- a/library/Dlayer/DesignerTool/ContentManager/Text/SubTool/Typography/Ribbon.php
+++ b/library/Dlayer/DesignerTool/ContentManager/Text/SubTool/Typography/Ribbon.php
@@ -76,13 +76,20 @@ class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Ribbon extends 
         if ($this->element_data_fetched === false) {
 
             $this->element_data = array(
-                'font_families' => false
+                'font_families' => false,
+                'text_weights' => false
             );
 
             $model = new Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Model();
+
             $font_families = $model->fontFamiliesForSelect();
-            if($font_families !== false) {
+            if ($font_families !== false) {
                 $this->element_data['font_families'] = $font_families;
+            }
+
+            $text_weights = $model->textWeightsForSelect();
+            if ($text_weights !== false) {
+                $this->element_data['text_weights'] = $text_weights;
             }
 
             $this->element_data_fetched = true;
@@ -103,13 +110,20 @@ class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Ribbon extends 
             $this->preview_data = array(
                 'id' => $this->tool['content_id'],
                 'font_family_id' => $this->content_data['font_family_id'],
-                'font_families' => false
+                'font_families' => false,
+                'text_weights' => false
             );
 
             $model = new Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Model();
+
             $font_families = $model->fontFamiliesForPreview();
-            if($font_families !== false) {
+            if ($font_families !== false) {
                 $this->preview_data['font_families'] = $font_families;
+            }
+
+            $text_weights = $model->textWeightsForPreview();
+            if ($text_weights !== false) {
+                $this->preview_data['text_weights'] = $text_weights;
             }
 
             $this->preview_data_fetched = true;

--- a/library/Dlayer/DesignerTool/ContentManager/Text/SubTool/Typography/Tool.php
+++ b/library/Dlayer/DesignerTool/ContentManager/Text/SubTool/Typography/Tool.php
@@ -119,8 +119,9 @@ class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Tool extends Dl
         $model = new Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Model();
 
         $id = $model->existingFontAndTextValues($this->site_id, $this->page_id, $this->content_id);
+        var_dump('Font family: ' . $id);
 
-        if ($id === false) {
+        /*if ($id === false) {
             try {
                 $model->addFontFamily(
                     $this->site_id,
@@ -141,7 +142,7 @@ class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Tool extends Dl
             } catch (Exception $e) {
                 throw new Exception($e->getMessage(), $e->getCode(), $e);
             }
-        }
+        }*/
     }
 
     /**
@@ -155,8 +156,9 @@ class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Tool extends Dl
         $model = new Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Model();
 
         $id = $model->existingFontAndTextValues($this->site_id, $this->page_id, $this->content_id);
+        var_dump('Text weight: ' . $id);
 
-        if ($id === false) {
+        /*if ($id === false) {
             try {
                 $model->addTextWeight(
                     $this->site_id,
@@ -177,7 +179,7 @@ class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Tool extends Dl
             } catch (Exception $e) {
                 throw new Exception($e->getMessage(), $e->getCode(), $e);
             }
-        }
+        }*/
     }
 
     /**

--- a/library/Dlayer/DesignerTool/ContentManager/Text/SubTool/Typography/Tool.php
+++ b/library/Dlayer/DesignerTool/ContentManager/Text/SubTool/Typography/Tool.php
@@ -102,6 +102,7 @@ class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Tool extends Dl
     {
         $this->fontFamily();
         $this->textWeight();
+        die;
 
         $this->cleanUp();
 
@@ -121,7 +122,7 @@ class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Tool extends Dl
         $id = $model->existingFontAndTextValues($this->site_id, $this->page_id, $this->content_id);
         var_dump('Font family: ' . $id);
 
-        /*if ($id === false) {
+        if ($id === false && $this->params['font_family_id'] !== DEFAULT_FONT_FAMILY_FOR_MODULE) {
             try {
                 $model->addFontFamily(
                     $this->site_id,
@@ -142,7 +143,7 @@ class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Tool extends Dl
             } catch (Exception $e) {
                 throw new Exception($e->getMessage(), $e->getCode(), $e);
             }
-        }*/
+        }
     }
 
     /**
@@ -158,7 +159,7 @@ class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Tool extends Dl
         $id = $model->existingFontAndTextValues($this->site_id, $this->page_id, $this->content_id);
         var_dump('Text weight: ' . $id);
 
-        /*if ($id === false) {
+        if ($id === false && $this->params['text_weight_id'] !== DEFAULT_TEXT_WEIGHT_FOR_MODULE)  {
             try {
                 $model->addTextWeight(
                     $this->site_id,
@@ -175,11 +176,11 @@ class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Tool extends Dl
             }
         } else {
             try {
-                $model->editFontFamily($id, $this->params['font_family_id']);
+                $model->editTextWeight($id, $this->params['text_weight_id']);
             } catch (Exception $e) {
                 throw new Exception($e->getMessage(), $e->getCode(), $e);
             }
-        }*/
+        }
     }
 
     /**

--- a/library/Dlayer/DesignerTool/ContentManager/Text/SubTool/Typography/Tool.php
+++ b/library/Dlayer/DesignerTool/ContentManager/Text/SubTool/Typography/Tool.php
@@ -93,7 +93,7 @@ class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Tool extends Dl
     }
 
     /**
-     * Edit a new content item or setting
+     * Edit a content item or setting
      *
      * @return array|FALSE Ids for new environment vars or FALSE if the request failed
      * @throws Exception
@@ -101,6 +101,7 @@ class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Tool extends Dl
     protected function edit()
     {
         $this->fontFamily();
+        $this->textWeight();
 
         $this->cleanUp();
 
@@ -114,6 +115,42 @@ class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Tool extends Dl
      * @throws Exception
      */
     protected function fontFamily()
+    {
+        $model = new Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Model();
+
+        $id = $model->existingFontFamily($this->site_id, $this->page_id, $this->content_id);
+
+        if ($id === false) {
+            try {
+                $model->addFontFamily(
+                    $this->site_id,
+                    $this->page_id,
+                    $this->content_id,
+                    $this->params['font_family_id']
+                );
+
+                Dlayer_Helper::sendToInfoLog('Set font family for text content item: ' . $this->content_id .
+                    ' site_id: ' . $this->site_id . ' page id: ' . $this->page_id .
+                    ' row id: ' . $this->row_id . ' column id: ' . $this->column_id);
+            } catch (Exception $e) {
+                throw new Exception($e->getMessage(), $e->getCode(), $e);
+            }
+        } else {
+            try {
+                $model->editFontFamily($id, $this->params['font_family_id']);
+            } catch (Exception $e) {
+                throw new Exception($e->getMessage(), $e->getCode(), $e);
+            }
+        }
+    }
+
+    /**
+     * Manage the text weight for a content item
+     *
+     * @return void
+     * @throws Exception
+     */
+    protected function textWeight()
     {
         $model = new Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Model();
 

--- a/library/Dlayer/DesignerTool/ContentManager/Text/SubTool/Typography/Tool.php
+++ b/library/Dlayer/DesignerTool/ContentManager/Text/SubTool/Typography/Tool.php
@@ -20,7 +20,9 @@ class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Tool extends Dl
     protected function paramsExist(array $params)
     {
         $valid = false;
-        if (array_key_exists('font_family_id', $params) === true) {
+        if (array_key_exists('font_family_id', $params) === true &&
+            array_key_exists('text_weight_id', $params) === true
+        ) {
             $valid = true;
         }
 
@@ -40,7 +42,8 @@ class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Tool extends Dl
 
         $model = new Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Model();
 
-        if($model->fontFamilyIdValid($params['font_family_id']) === true) {
+        if ($model->fontFamilyIdValid($params['font_family_id']) === true &&
+            $model->textWeightIdValid($params['text_weight_id']) === true) {
             $valid = true;
         }
 
@@ -59,6 +62,10 @@ class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Tool extends Dl
     {
         if (array_key_exists('font_family_id', $params) === true) {
             $this->params['font_family_id'] = intval($params['font_family_id']);
+        }
+
+        if (array_key_exists('text_weight_id', $params) === true) {
+            $this->params['text_weight_id'] = intval($params['text_weight_id']);
         }
     }
 
@@ -94,6 +101,8 @@ class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Tool extends Dl
     protected function edit()
     {
         $this->fontFamily();
+
+        $this->cleanUp();
 
         return $this->returnIds();
     }
@@ -132,6 +141,14 @@ class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Tool extends Dl
                 throw new Exception($e->getMessage(), $e->getCode(), $e);
             }
         }
+    }
+
+    /**
+     * Clean up the typography table if required, don't want null values stored if not necessary
+     */
+    protected function cleanUp()
+    {
+
     }
 
     /**

--- a/library/Dlayer/DesignerTool/ContentManager/Text/SubTool/Typography/Tool.php
+++ b/library/Dlayer/DesignerTool/ContentManager/Text/SubTool/Typography/Tool.php
@@ -118,7 +118,7 @@ class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Tool extends Dl
     {
         $model = new Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Model();
 
-        $id = $model->existingFontFamily($this->site_id, $this->page_id, $this->content_id);
+        $id = $model->existingFontAndTextValues($this->site_id, $this->page_id, $this->content_id);
 
         if ($id === false) {
             try {
@@ -154,18 +154,18 @@ class Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Tool extends Dl
     {
         $model = new Dlayer_DesignerTool_ContentManager_Text_SubTool_Typography_Model();
 
-        $id = $model->existingFontFamily($this->site_id, $this->page_id, $this->content_id);
+        $id = $model->existingFontAndTextValues($this->site_id, $this->page_id, $this->content_id);
 
         if ($id === false) {
             try {
-                $model->addFontFamily(
+                $model->addTextWeight(
                     $this->site_id,
                     $this->page_id,
                     $this->content_id,
-                    $this->params['font_family_id']
+                    $this->params['text_weight_id']
                 );
 
-                Dlayer_Helper::sendToInfoLog('Set font family for text content item: ' . $this->content_id .
+                Dlayer_Helper::sendToInfoLog('Set text weight for text content item: ' . $this->content_id .
                     ' site_id: ' . $this->site_id . ' page id: ' . $this->page_id .
                     ' row id: ' . $this->row_id . ' column id: ' . $this->column_id);
             } catch (Exception $e) {

--- a/library/Dlayer/Model/Settings.php
+++ b/library/Dlayer/Model/Settings.php
@@ -218,8 +218,8 @@ class Dlayer_Model_Settings extends Zend_Db_Table_Abstract
 	 */
 	public function setDefaultBaseFontFamilies($site_id)
 	{
-		$sql = "INSERT INTO user_setting_font_family
-				(site_id, module_id, font_family_id)
+		$sql = "INSERT INTO `user_setting_font_and_text`
+				(`site_id`, `module_id`, `font_family_id`)
 				VALUES
 				(:site_id, :module_id, :font_family_id)";
 		$stmt = $this->_db->prepare($sql);
@@ -371,12 +371,12 @@ class Dlayer_Model_Settings extends Zend_Db_Table_Abstract
      */
 	public function definedFontFamilyId($module, $site_id)
     {
-        $sql = "SELECT usff.`font_family_id` 
-                FROM user_setting_font_family usff 
-                JOIN dlayer_module dm ON
-                    usff.`module_id` = dm.id AND
-                    dm.`name` = :module 
-                WHERE usff.`site_id` = :site_id 
+        $sql = "SELECT `usfat`.`font_family_id` 
+                FROM `user_setting_font_and_text` `usfat` 
+                JOIN `dlayer_module` `dm` ON
+                    `usfat`.`module_id` = `dm`.`id` AND
+                    `dm`.`name` = :module 
+                WHERE `usfat`.`site_id` = :site_id 
                 LIMIT 1";
         $stmt = $this->_db->prepare($sql);
         $stmt->bindValue(':module', $module, PDO::PARAM_STR);

--- a/library/Dlayer/Model/Settings.php
+++ b/library/Dlayer/Model/Settings.php
@@ -367,16 +367,20 @@ class Dlayer_Model_Settings extends Zend_Db_Table_Abstract
      * @param string $module
      * @param integer $site_id
      *
-     * @return integer
+     * @return array|false
      */
-	public function definedFontFamilyId($module, $site_id)
+	public function definedFontAndTextSettings($module, $site_id)
     {
-        $sql = "SELECT `usfat`.`font_family_id` 
-                FROM `user_setting_font_and_text` `usfat` 
+        $sql = "SELECT 
+                    `usfat`.`font_family_id`, 
+                    `usfat`.`text_weight_id`
+                FROM 
+                    `user_setting_font_and_text` `usfat` 
                 JOIN `dlayer_module` `dm` ON
                     `usfat`.`module_id` = `dm`.`id` AND
                     `dm`.`name` = :module 
-                WHERE `usfat`.`site_id` = :site_id 
+                WHERE 
+                    `usfat`.`site_id` = :site_id 
                 LIMIT 1";
         $stmt = $this->_db->prepare($sql);
         $stmt->bindValue(':module', $module, PDO::PARAM_STR);
@@ -386,9 +390,9 @@ class Dlayer_Model_Settings extends Zend_Db_Table_Abstract
         $result = $stmt->fetch();
 
         if($result !== false) {
-            return intval($result['font_family_id']);
+            return $result;
         } else {
-            return 1;
+            return false;
         }
     }
 }

--- a/library/Dlayer/Model/Settings/Content.php
+++ b/library/Dlayer/Model/Settings/Content.php
@@ -53,14 +53,15 @@ class Dlayer_Model_Settings_Content extends Zend_Db_Table_Abstract
 	*/
 	public function baseFontFamily($site_id)
 	{
-		$sql = "SELECT dcff.id, dcff.css, dcff.`name`
-				FROM user_setting_font_family usff
-				JOIN dlayer_module dm ON usff.module_id = dm.id
-				AND dm.enabled = 1
-				JOIN designer_css_font_family dcff
-				ON usff.font_family_id = dcff.id
-				WHERE usff.site_id = :site_id
-				AND dm.`name` = :module";
+		$sql = "SELECT `dcff`.`id`, `dcff`.`css`, `dcff`.`name`
+				FROM `user_setting_font_and_text` `usfat`
+				JOIN `dlayer_module` `dm` ON 
+				    `usfat`.`module_id` = `dm`.`id`
+				AND `dm`.`enabled` = 1
+				JOIN `designer_css_font_family` `dcff`ON 
+				    `usfat`.`font_family_id` = `dcff`.`id`
+				WHERE `usfat`.`site_id` = :site_id
+				AND `dm`.`name` = :module";
 		$stmt = $this->_db->prepare($sql);
 		$stmt->bindValue(':site_id', $site_id, PDO::PARAM_INT);
 		$stmt->bindValue(':module', 'content', PDO::PARAM_STR);
@@ -105,10 +106,10 @@ class Dlayer_Model_Settings_Content extends Zend_Db_Table_Abstract
 	*/
 	public function updateFontFamily($site_id, $font_family_id)
 	{
-		$sql = "UPDATE user_setting_font_family
-				SET font_family_id = :font_family_id
-				WHERE site_id = :site_id
-				AND module_id = (SELECT id FROM dlayer_module
+		$sql = "UPDATE `user_setting_font_and_text`
+				SET `font_family_id` = :font_family_id
+				WHERE `site_id` = :site_id
+				AND `module_id` = (SELECT id FROM dlayer_module
 				WHERE `name` = :module)
 				LIMIT 1";
 		$stmt = $this->_db->prepare($sql);

--- a/library/Dlayer/Model/Settings/Form.php
+++ b/library/Dlayer/Model/Settings/Form.php
@@ -22,7 +22,7 @@ class Dlayer_Model_Settings_Form extends Zend_Db_Table_Abstract
 	public function baseFontFamily($site_id)
 	{
 		$sql = "SELECT dcff.id, dcff.css, dcff.`name`
-				FROM user_setting_font_family usff
+				FROM user_setting_font_and_text usff
 				JOIN dlayer_module dm ON usff.module_id = dm.id
 				AND dm.enabled = 1
 				JOIN designer_css_font_family dcff
@@ -46,11 +46,20 @@ class Dlayer_Model_Settings_Form extends Zend_Db_Table_Abstract
 	*/
 	public function updateFontFamily($site_id, $font_family_id)
 	{
-		$sql = "UPDATE user_setting_font_family
-				SET font_family_id = :font_family_id
-				WHERE site_id = :site_id
-				AND module_id = (SELECT id FROM dlayer_module
-				WHERE `name` = :module)
+		$sql = "UPDATE 
+                    `user_setting_font_and_text`
+				SET 
+				    `font_family_id` = :font_family_id
+				WHERE 
+				    `site_id` = :site_id AND 
+				    `module_id` = (
+				        SELECT 
+				            `id` 
+                        FROM 
+                            `dlayer_module`
+                        WHERE 
+                            `name` = :module
+                        )
 				LIMIT 1";
 		$stmt = $this->_db->prepare($sql);
 		$stmt->bindValue(':site_id', $site_id, PDO::PARAM_INT);

--- a/library/Dlayer/Model/View/ContentPage/Styling.php
+++ b/library/Dlayer/Model/View/ContentPage/Styling.php
@@ -52,7 +52,8 @@ class Dlayer_Model_View_ContentPage_Styling extends Zend_Db_Table_Abstract
     {
         return array(
             'background_color' => $this->contentItemBackgroundColors(),
-            'font_family' => $this->contentItemFontFamilies()
+            'font_family' => $this->contentItemFontFamilies(),
+            'text_weight' => $this->contentItemTextWeights()
         );
     }
 
@@ -113,7 +114,7 @@ class Dlayer_Model_View_ContentPage_Styling extends Zend_Db_Table_Abstract
 
         $styles = array();
 
-        foreach($stmt->fetchAll() as $row) {
+        foreach ($stmt->fetchAll() as $row) {
             $styles[intval($row['content_id'])] = $row['background_color'];
         }
 
@@ -127,12 +128,17 @@ class Dlayer_Model_View_ContentPage_Styling extends Zend_Db_Table_Abstract
      */
     private function contentItemFontFamilies()
     {
-        $sql = "SELECT uspscit.content_id, dcff.css 
-                FROM user_site_page_styling_content_item_typography uspscit 
-                JOIN designer_css_font_family dcff 
-                    ON uspscit.font_family_id = dcff.id 
-                WHERE uspscit.site_id = :site_id 
-                AND uspscit.page_id = :page_id";
+        $sql = "SELECT 
+                    `uspscit`.`content_id`, 
+                    `dcff`.`css` 
+                FROM 
+                    `user_site_page_styling_content_item_typography` `uspscit` 
+                JOIN 
+                    `designer_css_font_family` `dcff` ON 
+                        `uspscit`.`font_family_id` = `dcff`.`id` 
+                WHERE 
+                    `uspscit`.`site_id` = :site_id AND 
+                    `uspscit`.`page_id` = :page_id";
         $stmt = $this->_db->prepare($sql);
         $stmt->bindValue(':site_id', $this->site_id);
         $stmt->bindValue(':page_id', $this->page_id);
@@ -140,8 +146,40 @@ class Dlayer_Model_View_ContentPage_Styling extends Zend_Db_Table_Abstract
 
         $styles = array();
 
-        foreach($stmt->fetchAll() as $row) {
+        foreach ($stmt->fetchAll() as $row) {
             $styles[intval($row['content_id'])] = $row['css'];
+        }
+
+        return $styles;
+    }
+
+    /**
+     * Fetch the defined text weights indexed by content id
+     *
+     * @return array
+     */
+    private function contentItemTextWeights()
+    {
+        $sql = "SELECT 
+                    `uspscit`.`content_id`, 
+                    `dctw`.`css` 
+                FROM 
+                    `user_site_page_styling_content_item_typography` `uspscit` 
+                JOIN 
+                    `designer_css_text_weight` `dctw` ON 
+                        `uspscit`.`text_weight_id` = `dctw`.`id` 
+                WHERE 
+                    `uspscit`.`site_id` = :site_id AND 
+                    `uspscit`.`page_id` = :page_id";
+        $stmt = $this->_db->prepare($sql);
+        $stmt->bindValue(':site_id', $this->site_id);
+        $stmt->bindValue(':page_id', $this->page_id);
+        $stmt->execute();
+
+        $styles = array();
+
+        foreach ($stmt->fetchAll() as $row) {
+            $styles[intval($row['content_id'])] = intval($row['css']);
         }
 
         return $styles;
@@ -165,7 +203,7 @@ class Dlayer_Model_View_ContentPage_Styling extends Zend_Db_Table_Abstract
 
         $styles = array();
 
-        foreach($stmt->fetchAll() as $row) {
+        foreach ($stmt->fetchAll() as $row) {
             $styles[intval($row['column_id'])] = $row['background_color'];
         }
 
@@ -190,7 +228,7 @@ class Dlayer_Model_View_ContentPage_Styling extends Zend_Db_Table_Abstract
 
         $styles = array();
 
-        foreach($stmt->fetchAll() as $row) {
+        foreach ($stmt->fetchAll() as $row) {
             $styles[intval($row['row_id'])] = $row['background_color'];
         }
 
@@ -215,7 +253,7 @@ class Dlayer_Model_View_ContentPage_Styling extends Zend_Db_Table_Abstract
 
         $styles = array();
 
-        foreach($stmt->fetchAll() as $row) {
+        foreach ($stmt->fetchAll() as $row) {
             $styles[intval($row['page_id'])] = $row['background_color'];
         }
 

--- a/library/Dlayer/Model/View/Settings.php
+++ b/library/Dlayer/Model/View/Settings.php
@@ -46,13 +46,20 @@ class Dlayer_Model_View_Settings extends Zend_Db_Table_Abstract
 	*/
 	public function baseFontFamily($site_id, $module)
 	{
-		$sql = "SELECT dcff.css AS font_family
-				FROM user_setting_font_family usff
-				JOIN dlayer_module dm ON usff.module_id = dm.id
-				JOIN designer_css_font_family dcff
-					ON usff.font_family_id = dcff.id
-				WHERE usff.site_id = :site_id
-				AND dm.`name` = :module";
+		$sql = "SELECT 
+                    `dcff`.`css` AS `font_family`
+				FROM 
+				    `user_setting_font_and_text` `usfat`
+				JOIN 
+				    `dlayer_module` `dm` ON 
+				        `usfat`.`module_id` = `dm`.`id`
+				JOIN 
+				    `designer_css_font_family` `dcff` ON 
+				        `usfat`.`font_family_id` = `dcff`.`id`
+				WHERE 
+				    `usfat`.`site_id` = :site_id
+				AND 
+				    `dm`.`name` = :module";
 		$stmt = $this->_db->prepare($sql);
 		$stmt->bindValue(':site_id', $site_id, PDO::PARAM_INT);
 		$stmt->bindValue(':module', $module, PDO::PARAM_STR);

--- a/library/Dlayer/View/Codehinting.php
+++ b/library/Dlayer/View/Codehinting.php
@@ -302,6 +302,17 @@ class Dlayer_View_Codehinting extends Zend_View_Helper_Abstract
     }
 
     /**
+     * Text weight style attribute
+     *
+     * @param integer $text_weight The text weight setting
+     *
+     * @return Dlayer_View_StylingAttributeTextWeight
+     */
+    public function stylingAttributeTextWeight($text_weight)
+    {
+    }
+
+    /**
      * Styles for columns
      *
      * @return Dlayer_View_StylingColumn

--- a/library/Dlayer/View/StylingAttributeTextWeight.php
+++ b/library/Dlayer/View/StylingAttributeTextWeight.php
@@ -1,13 +1,13 @@
 <?php
 
 /**
- * Styling view helper, generates the font family attribute
+ * Styling view helper, generates the text weight attribute
  *
  * @author Dean Blackborough <dean@g3d-development.com>
  * @copyright G3D Development Limited
  * @license https://github.com/Dlayer/dlayer/blob/master/LICENSE
  */
-class Dlayer_View_StylingAttributeFontFamily extends Zend_View_Helper_Abstract
+class Dlayer_View_StylingAttributeTextWeight extends Zend_View_Helper_Abstract
 {
     /**
      * @var string The complete style attribute
@@ -15,22 +15,22 @@ class Dlayer_View_StylingAttributeFontFamily extends Zend_View_Helper_Abstract
     private $style;
 
     /**
-     * @var string $font_family
+     * @var integer $text_weight
      */
-    private $font_family;
+    private $text_weight;
 
     /**
      * View helper constructor, pass in anything that may be needed to create the object
      *
-     * @param string $font_family The font family setting
+     * @param integer $text_weight The text weight setting
      *
-     * @return Dlayer_View_StylingAttributeFontFamily
+     * @return Dlayer_View_StylingAttributeTextWeight
      */
-    public function stylingAttributeFontFamily($font_family)
+    public function stylingAttributeTextWeight($text_weight)
     {
         $this->resetParams();
 
-        $this->font_family = $font_family;
+        $this->text_weight = $text_weight;
 
         return $this;
     }
@@ -43,7 +43,7 @@ class Dlayer_View_StylingAttributeFontFamily extends Zend_View_Helper_Abstract
     private function resetParams()
     {
         $this->style = '';
-        $this->font_family = null;
+        $this->text_weight = null;
     }
 
     /**
@@ -53,7 +53,7 @@ class Dlayer_View_StylingAttributeFontFamily extends Zend_View_Helper_Abstract
      */
     private function render()
     {
-        $this->style .= ' font-family:' . $this->view->escape($this->font_family) . ';';
+        $this->style .= ' font-weight:' . $this->text_weight . ';';
 
         return $this->style;
     }

--- a/library/Dlayer/View/StylingContentItem.php
+++ b/library/Dlayer/View/StylingContentItem.php
@@ -98,6 +98,12 @@ class Dlayer_View_StylingContentItem extends Zend_View_Helper_Abstract
                 $styles .= $this->view->stylingAttributeFontFamily($this->styles['font_family'][$this->id]);
             }
 
+            if (array_key_exists('text_weight', $this->styles) === true &&
+                array_key_exists($this->id, $this->styles['text_weight']) === true
+            ) {
+                $styles .= $this->view->stylingAttributeTextWeight($this->styles['text_weight'][$this->id]);
+            }
+
             if (strlen($styles) > 0) {
                 $styles = ' style="' . $styles . '"';
             }

--- a/private/database/release-database.sql
+++ b/private/database/release-database.sql
@@ -397,7 +397,7 @@ CREATE TABLE `dlayer_identity` (
 /*Data for the table `dlayer_identity` */
 
 insert  into `dlayer_identity`(`id`,`identity`,`credentials`,`logged_in`,`last_login`,`last_action`,`enabled`) values 
-(1,'user-1@dlayer.com','$6$rounds=5000$jks453yuyt55d$CZJCjaieFQghQ6MwQ1OUI5nVKDy/Fi2YXk7MyW2hcex9AdJ/jvZA8ulvjzK1lo3rRVFfmd10lgjqAbDQM4ehR1',0,'2016-12-24 12:30:21','2016-12-24 12:45:34',1),
+(1,'user-1@dlayer.com','$6$rounds=5000$jks453yuyt55d$CZJCjaieFQghQ6MwQ1OUI5nVKDy/Fi2YXk7MyW2hcex9AdJ/jvZA8ulvjzK1lo3rRVFfmd10lgjqAbDQM4ehR1',0,'2016-12-24 23:21:35','2016-12-24 23:44:27',1),
 (2,'user-2@dlayer.com','$6$rounds=5000$jks453yuyt55d$ZVEJgs2kNjxOxNEayqqoh2oJUiGbmxIKRqOTxVM05MP2YRcAjE9adCZfQBWCc.qe1nDjEM9.ioivNz3c/qyZ80',0,'2015-05-29 15:57:54','2015-05-29 15:58:47',1),
 (3,'user-3@dlayer.com','$6$rounds=5000$jks453yuyt55d$NYF6yCvxXplefx7nr8vDe4cUGBEFtd3G5vuJ2utfqvPwEf3dSgNXNTcGbFO6WrJSn21CXHgZwNOQHy691E/Rm.',0,'2015-05-29 15:59:10','2015-05-29 16:25:10',1);
 
@@ -673,7 +673,8 @@ CREATE TABLE `dlayer_session` (
 /*Data for the table `dlayer_session` */
 
 insert  into `dlayer_session`(`session_id`,`save_path`,`name`,`modified`,`lifetime`,`session_data`) values 
-('rurvk3qdusgvdqpk2e96phb5p3','C:\\Users\\g3d\\Documents\\Xampp\\tmp','PHPSESSID',1482583664,3601,'__ZF|a:3:{s:14:\"dlayer_session\";a:1:{s:3:\"ENT\";i:1482587264;}s:22:\"dlayer_session_content\";a:1:{s:3:\"ENT\";i:1482587263;}s:23:\"dlayer_session_designer\";a:1:{s:3:\"ENT\";i:1482587263;}}dlayer_session_content|a:5:{s:7:\"page_id\";N;s:13:\"page_selected\";N;s:9:\"column_id\";N;s:6:\"row_id\";N;s:10:\"content_id\";N;}dlayer_session_designer|a:7:{s:4:\"tool\";a:1:{s:7:\"content\";N;}s:3:\"tab\";a:1:{s:7:\"content\";N;}s:8:\"sub_tool\";a:1:{s:7:\"content\";N;}s:24:\"image_picker_category_id\";N;s:28:\"image_picker_sub_category_id\";N;s:21:\"image_picker_image_id\";N;s:23:\"image_picker_version_id\";N;}dlayer_session|a:1:{s:7:\"site_id\";N;}');
+('bjmqaanjqhgfb81e0fkmsmnl75','C:\\Users\\g3d\\Documents\\Xampp\\tmp','PHPSESSID',1482595431,3601,'__ZF|a:1:{s:14:\"dlayer_session\";a:1:{s:3:\"ENT\";i:1482599031;}}dlayer_session|a:1:{s:7:\"site_id\";N;}'),
+('rurvk3qdusgvdqpk2e96phb5p3','C:\\Users\\g3d\\Documents\\Xampp\\tmp','PHPSESSID',1482623100,3601,'__ZF|a:3:{s:14:\"dlayer_session\";a:1:{s:3:\"ENT\";i:1482626700;}s:22:\"dlayer_session_content\";a:1:{s:3:\"ENT\";i:1482626700;}s:23:\"dlayer_session_designer\";a:1:{s:3:\"ENT\";i:1482626700;}}dlayer_session_content|a:5:{s:7:\"page_id\";N;s:13:\"page_selected\";N;s:9:\"column_id\";N;s:6:\"row_id\";N;s:10:\"content_id\";N;}dlayer_session_designer|a:7:{s:4:\"tool\";a:1:{s:7:\"content\";N;}s:3:\"tab\";a:1:{s:7:\"content\";N;}s:8:\"sub_tool\";a:1:{s:7:\"content\";N;}s:24:\"image_picker_category_id\";N;s:28:\"image_picker_sub_category_id\";N;s:21:\"image_picker_image_id\";N;s:23:\"image_picker_version_id\";N;}dlayer_session|a:1:{s:7:\"site_id\";N;}');
 
 /*Table structure for table `dlayer_setting` */
 
@@ -2090,14 +2091,15 @@ CREATE TABLE `user_site_page_styling_content_item_typography` (
   CONSTRAINT `user_site_page_styling_content_item_typography_ibfk_3` FOREIGN KEY (`content_id`) REFERENCES `user_site_page_structure_content` (`id`),
   CONSTRAINT `user_site_page_styling_content_item_typography_ibfk_4` FOREIGN KEY (`font_family_id`) REFERENCES `designer_css_font_family` (`id`),
   CONSTRAINT `user_site_page_styling_content_item_typography_ibfk_5` FOREIGN KEY (`text_weight_id`) REFERENCES `designer_css_text_weight` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=10 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `user_site_page_styling_content_item_typography` */
 
 insert  into `user_site_page_styling_content_item_typography`(`id`,`site_id`,`page_id`,`content_id`,`font_family_id`,`text_weight_id`) values 
-(2,1,3,28,2,NULL),
 (3,1,3,31,5,NULL),
-(4,1,2,16,5,NULL);
+(4,1,2,16,5,NULL),
+(5,1,3,29,2,NULL),
+(9,1,3,28,5,2);
 
 /*Table structure for table `user_site_page_styling_page_background_color` */
 

--- a/private/database/release-database.sql
+++ b/private/database/release-database.sql
@@ -978,26 +978,29 @@ CREATE TABLE `user_setting_font_and_text` (
   `site_id` int(11) unsigned NOT NULL,
   `module_id` tinyint(3) unsigned NOT NULL,
   `font_family_id` tinyint(3) unsigned NOT NULL,
+  `text_weight_id` tinyint(3) unsigned NOT NULL,
   PRIMARY KEY (`id`),
   KEY `site_id` (`site_id`),
   KEY `module_id` (`module_id`),
   KEY `font_family_id` (`font_family_id`),
+  KEY `text_weight_id` (`text_weight_id`),
   CONSTRAINT `user_setting_font_and_text_ibfk_1` FOREIGN KEY (`site_id`) REFERENCES `user_site` (`id`),
   CONSTRAINT `user_setting_font_and_text_ibfk_2` FOREIGN KEY (`module_id`) REFERENCES `dlayer_module` (`id`),
-  CONSTRAINT `user_setting_font_and_text_ibfk_3` FOREIGN KEY (`font_family_id`) REFERENCES `designer_css_font_family` (`id`)
+  CONSTRAINT `user_setting_font_and_text_ibfk_3` FOREIGN KEY (`font_family_id`) REFERENCES `designer_css_font_family` (`id`),
+  CONSTRAINT `user_setting_font_and_text_ibfk_4` FOREIGN KEY (`text_weight_id`) REFERENCES `designer_css_text_weight` (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=9 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `user_setting_font_and_text` */
 
-insert  into `user_setting_font_and_text`(`id`,`site_id`,`module_id`,`font_family_id`) values 
-(1,1,3,8),
-(2,1,4,1),
-(3,2,3,1),
-(4,2,4,1),
-(5,3,3,1),
-(6,3,4,1),
-(7,4,3,1),
-(8,4,4,1);
+insert  into `user_setting_font_and_text`(`id`,`site_id`,`module_id`,`font_family_id`,`text_weight_id`) values 
+(1,1,3,8,1),
+(2,1,4,1,1),
+(3,2,3,1,1),
+(4,2,4,1,1),
+(5,3,3,1,1),
+(6,3,4,1,1),
+(7,4,3,1,1),
+(8,4,4,1,1);
 
 /*Table structure for table `user_setting_heading` */
 

--- a/private/database/release-database.sql
+++ b/private/database/release-database.sql
@@ -397,7 +397,7 @@ CREATE TABLE `dlayer_identity` (
 /*Data for the table `dlayer_identity` */
 
 insert  into `dlayer_identity`(`id`,`identity`,`credentials`,`logged_in`,`last_login`,`last_action`,`enabled`) values 
-(1,'user-1@dlayer.com','$6$rounds=5000$jks453yuyt55d$CZJCjaieFQghQ6MwQ1OUI5nVKDy/Fi2YXk7MyW2hcex9AdJ/jvZA8ulvjzK1lo3rRVFfmd10lgjqAbDQM4ehR1',0,'2016-12-23 17:56:42','2016-12-23 17:57:15',1),
+(1,'user-1@dlayer.com','$6$rounds=5000$jks453yuyt55d$CZJCjaieFQghQ6MwQ1OUI5nVKDy/Fi2YXk7MyW2hcex9AdJ/jvZA8ulvjzK1lo3rRVFfmd10lgjqAbDQM4ehR1',0,'2016-12-24 12:30:21','2016-12-24 12:45:34',1),
 (2,'user-2@dlayer.com','$6$rounds=5000$jks453yuyt55d$ZVEJgs2kNjxOxNEayqqoh2oJUiGbmxIKRqOTxVM05MP2YRcAjE9adCZfQBWCc.qe1nDjEM9.ioivNz3c/qyZ80',0,'2015-05-29 15:57:54','2015-05-29 15:58:47',1),
 (3,'user-3@dlayer.com','$6$rounds=5000$jks453yuyt55d$NYF6yCvxXplefx7nr8vDe4cUGBEFtd3G5vuJ2utfqvPwEf3dSgNXNTcGbFO6WrJSn21CXHgZwNOQHy691E/Rm.',0,'2015-05-29 15:59:10','2015-05-29 16:25:10',1);
 
@@ -673,7 +673,7 @@ CREATE TABLE `dlayer_session` (
 /*Data for the table `dlayer_session` */
 
 insert  into `dlayer_session`(`session_id`,`save_path`,`name`,`modified`,`lifetime`,`session_data`) values 
-('rurvk3qdusgvdqpk2e96phb5p3','C:\\Users\\g3d\\Documents\\Xampp\\tmp','PHPSESSID',1482515838,3601,'__ZF|a:3:{s:14:\"dlayer_session\";a:1:{s:3:\"ENT\";i:1482519438;}s:22:\"dlayer_session_content\";a:1:{s:3:\"ENT\";i:1482519438;}s:23:\"dlayer_session_designer\";a:1:{s:3:\"ENT\";i:1482519438;}}dlayer_session_content|a:5:{s:13:\"page_selected\";N;s:9:\"column_id\";N;s:6:\"row_id\";N;s:10:\"content_id\";N;s:7:\"page_id\";N;}dlayer_session_designer|a:7:{s:24:\"image_picker_category_id\";N;s:28:\"image_picker_sub_category_id\";N;s:21:\"image_picker_image_id\";N;s:23:\"image_picker_version_id\";N;s:4:\"tool\";a:1:{s:7:\"content\";N;}s:8:\"sub_tool\";a:1:{s:7:\"content\";N;}s:3:\"tab\";a:1:{s:7:\"content\";N;}}dlayer_session|a:1:{s:7:\"site_id\";N;}');
+('rurvk3qdusgvdqpk2e96phb5p3','C:\\Users\\g3d\\Documents\\Xampp\\tmp','PHPSESSID',1482583664,3601,'__ZF|a:3:{s:14:\"dlayer_session\";a:1:{s:3:\"ENT\";i:1482587264;}s:22:\"dlayer_session_content\";a:1:{s:3:\"ENT\";i:1482587263;}s:23:\"dlayer_session_designer\";a:1:{s:3:\"ENT\";i:1482587263;}}dlayer_session_content|a:5:{s:7:\"page_id\";N;s:13:\"page_selected\";N;s:9:\"column_id\";N;s:6:\"row_id\";N;s:10:\"content_id\";N;}dlayer_session_designer|a:7:{s:4:\"tool\";a:1:{s:7:\"content\";N;}s:3:\"tab\";a:1:{s:7:\"content\";N;}s:8:\"sub_tool\";a:1:{s:7:\"content\";N;}s:24:\"image_picker_category_id\";N;s:28:\"image_picker_sub_category_id\";N;s:21:\"image_picker_image_id\";N;s:23:\"image_picker_version_id\";N;}dlayer_session|a:1:{s:7:\"site_id\";N;}');
 
 /*Table structure for table `dlayer_setting` */
 
@@ -2003,9 +2003,9 @@ insert  into `user_site_page_structure_row`(`id`,`site_id`,`page_id`,`column_id`
 (10,1,1,0,4),
 (11,1,1,0,5),
 (12,1,2,0,4),
-(13,1,3,0,2),
+(13,1,3,0,1),
 (14,1,3,0,3),
-(15,1,3,0,1),
+(15,1,3,0,2),
 (16,1,3,0,4);
 
 /*Table structure for table `user_site_page_styling_column_background_color` */
@@ -2077,24 +2077,27 @@ CREATE TABLE `user_site_page_styling_content_item_typography` (
   `site_id` int(11) unsigned NOT NULL,
   `page_id` int(11) unsigned NOT NULL,
   `content_id` int(11) unsigned NOT NULL,
-  `font_family_id` tinyint(3) unsigned NOT NULL,
+  `font_family_id` tinyint(3) unsigned DEFAULT NULL,
+  `text_weight_id` tinyint(3) unsigned DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `site_id` (`site_id`),
   KEY `page_id` (`page_id`),
   KEY `content_id` (`content_id`),
   KEY `font_family_id` (`font_family_id`),
+  KEY `text_weight_id` (`text_weight_id`),
   CONSTRAINT `user_site_page_styling_content_item_typography_ibfk_1` FOREIGN KEY (`site_id`) REFERENCES `user_site` (`id`),
   CONSTRAINT `user_site_page_styling_content_item_typography_ibfk_2` FOREIGN KEY (`page_id`) REFERENCES `user_site_page` (`id`),
   CONSTRAINT `user_site_page_styling_content_item_typography_ibfk_3` FOREIGN KEY (`content_id`) REFERENCES `user_site_page_structure_content` (`id`),
-  CONSTRAINT `user_site_page_styling_content_item_typography_ibfk_4` FOREIGN KEY (`font_family_id`) REFERENCES `designer_css_font_family` (`id`)
+  CONSTRAINT `user_site_page_styling_content_item_typography_ibfk_4` FOREIGN KEY (`font_family_id`) REFERENCES `designer_css_font_family` (`id`),
+  CONSTRAINT `user_site_page_styling_content_item_typography_ibfk_5` FOREIGN KEY (`text_weight_id`) REFERENCES `designer_css_text_weight` (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `user_site_page_styling_content_item_typography` */
 
-insert  into `user_site_page_styling_content_item_typography`(`id`,`site_id`,`page_id`,`content_id`,`font_family_id`) values 
-(2,1,3,28,2),
-(3,1,3,31,5),
-(4,1,2,16,5);
+insert  into `user_site_page_styling_content_item_typography`(`id`,`site_id`,`page_id`,`content_id`,`font_family_id`,`text_weight_id`) values 
+(2,1,3,28,2,NULL),
+(3,1,3,31,5,NULL),
+(4,1,2,16,5,NULL);
 
 /*Table structure for table `user_site_page_styling_page_background_color` */
 

--- a/private/database/release-database.sql
+++ b/private/database/release-database.sql
@@ -397,7 +397,7 @@ CREATE TABLE `dlayer_identity` (
 /*Data for the table `dlayer_identity` */
 
 insert  into `dlayer_identity`(`id`,`identity`,`credentials`,`logged_in`,`last_login`,`last_action`,`enabled`) values 
-(1,'user-1@dlayer.com','$6$rounds=5000$jks453yuyt55d$CZJCjaieFQghQ6MwQ1OUI5nVKDy/Fi2YXk7MyW2hcex9AdJ/jvZA8ulvjzK1lo3rRVFfmd10lgjqAbDQM4ehR1',0,'2016-12-20 21:43:27','2016-12-20 22:04:01',1),
+(1,'user-1@dlayer.com','$6$rounds=5000$jks453yuyt55d$CZJCjaieFQghQ6MwQ1OUI5nVKDy/Fi2YXk7MyW2hcex9AdJ/jvZA8ulvjzK1lo3rRVFfmd10lgjqAbDQM4ehR1',0,'2016-12-23 17:56:42','2016-12-23 17:57:15',1),
 (2,'user-2@dlayer.com','$6$rounds=5000$jks453yuyt55d$ZVEJgs2kNjxOxNEayqqoh2oJUiGbmxIKRqOTxVM05MP2YRcAjE9adCZfQBWCc.qe1nDjEM9.ioivNz3c/qyZ80',0,'2015-05-29 15:57:54','2015-05-29 15:58:47',1),
 (3,'user-3@dlayer.com','$6$rounds=5000$jks453yuyt55d$NYF6yCvxXplefx7nr8vDe4cUGBEFtd3G5vuJ2utfqvPwEf3dSgNXNTcGbFO6WrJSn21CXHgZwNOQHy691E/Rm.',0,'2015-05-29 15:59:10','2015-05-29 16:25:10',1);
 
@@ -673,28 +673,7 @@ CREATE TABLE `dlayer_session` (
 /*Data for the table `dlayer_session` */
 
 insert  into `dlayer_session`(`session_id`,`save_path`,`name`,`modified`,`lifetime`,`session_data`) values 
-('11f5ll1vgiduvsodus7b4db1d2','C:\\Users\\g3d\\Documents\\Xampp\\tmp','PHPSESSID',1480376664,3601,'__ZF|a:3:{s:14:\"dlayer_session\";a:1:{s:3:\"ENT\";i:1480380264;}s:22:\"dlayer_session_content\";a:1:{s:3:\"ENT\";i:1480380264;}s:23:\"dlayer_session_designer\";a:1:{s:3:\"ENT\";i:1480380264;}}dlayer_session_content|a:5:{s:7:\"page_id\";N;s:13:\"page_selected\";N;s:9:\"column_id\";N;s:6:\"row_id\";N;s:10:\"content_id\";N;}dlayer_session_designer|a:7:{s:4:\"tool\";a:1:{s:7:\"content\";N;}s:3:\"tab\";a:1:{s:7:\"content\";N;}s:8:\"sub_tool\";a:1:{s:7:\"content\";N;}s:24:\"image_picker_category_id\";N;s:28:\"image_picker_sub_category_id\";N;s:21:\"image_picker_image_id\";N;s:23:\"image_picker_version_id\";N;}'),
-('18bpls1qdo9juer8s6j0vmhu82','C:\\Users\\g3d\\Documents\\Xampp\\tmp','PHPSESSID',1482271511,3601,'__ZF|a:3:{s:14:\"dlayer_session\";a:1:{s:3:\"ENT\";i:1482275111;}s:22:\"dlayer_session_content\";a:1:{s:3:\"ENT\";i:1482275110;}s:23:\"dlayer_session_designer\";a:1:{s:3:\"ENT\";i:1482275110;}}dlayer_session_content|a:5:{s:7:\"page_id\";N;s:13:\"page_selected\";N;s:9:\"column_id\";N;s:6:\"row_id\";N;s:10:\"content_id\";N;}dlayer_session_designer|a:7:{s:4:\"tool\";a:1:{s:7:\"content\";N;}s:3:\"tab\";a:1:{s:7:\"content\";N;}s:8:\"sub_tool\";a:1:{s:7:\"content\";N;}s:24:\"image_picker_category_id\";N;s:28:\"image_picker_sub_category_id\";N;s:21:\"image_picker_image_id\";N;s:23:\"image_picker_version_id\";N;}dlayer_session|a:1:{s:7:\"site_id\";N;}'),
-('3mh37m0s21j73mdn0e0l349c53','C:\\Users\\g3d\\Documents\\Xampp\\tmp','PHPSESSID',1481143252,3601,'__ZF|a:1:{s:14:\"dlayer_session\";a:1:{s:3:\"ENT\";i:1481146851;}}'),
-('56abovk90o5jvntvnlv51po8u4','C:\\Users\\g3d\\Documents\\Xampp\\tmp','PHPSESSID',1480462897,3601,'__ZF|a:1:{s:14:\"dlayer_session\";a:1:{s:3:\"ENT\";i:1480466497;}}'),
-('7kkeuoqad6mbbvtpkjvga71vk1','C:\\Users\\g3d\\Documents\\Xampp\\tmp','PHPSESSID',1480868764,3601,'__ZF|a:3:{s:14:\"dlayer_session\";a:1:{s:3:\"ENT\";i:1480872363;}s:22:\"dlayer_session_content\";a:1:{s:3:\"ENT\";i:1480872363;}s:23:\"dlayer_session_designer\";a:1:{s:3:\"ENT\";i:1480872363;}}dlayer_session_content|a:5:{s:7:\"page_id\";N;s:13:\"page_selected\";N;s:9:\"column_id\";N;s:6:\"row_id\";N;s:10:\"content_id\";N;}dlayer_session_designer|a:7:{s:4:\"tool\";a:1:{s:7:\"content\";N;}s:3:\"tab\";a:1:{s:7:\"content\";N;}s:8:\"sub_tool\";a:1:{s:7:\"content\";N;}s:24:\"image_picker_category_id\";N;s:28:\"image_picker_sub_category_id\";N;s:21:\"image_picker_image_id\";N;s:23:\"image_picker_version_id\";N;}'),
-('968c4aumno9eroq1u3pe5hlvv7','C:\\Users\\g3d\\Documents\\Xampp\\tmp','PHPSESSID',1479683298,3601,'__ZF|a:3:{s:14:\"dlayer_session\";a:1:{s:3:\"ENT\";i:1479686898;}s:22:\"dlayer_session_content\";a:1:{s:3:\"ENT\";i:1479686898;}s:23:\"dlayer_session_designer\";a:1:{s:3:\"ENT\";i:1479686898;}}dlayer_session|a:3:{s:11:\"identity_id\";i:1;s:7:\"site_id\";i:1;s:6:\"module\";s:7:\"content\";}dlayer_session_content|a:5:{s:7:\"page_id\";i:1;s:13:\"page_selected\";N;s:9:\"column_id\";N;s:6:\"row_id\";N;s:10:\"content_id\";N;}dlayer_session_designer|a:7:{s:4:\"tool\";a:1:{s:7:\"content\";N;}s:3:\"tab\";a:1:{s:7:\"content\";N;}s:8:\"sub_tool\";a:1:{s:7:\"content\";N;}s:24:\"image_picker_category_id\";N;s:28:\"image_picker_sub_category_id\";N;s:21:\"image_picker_image_id\";N;s:23:\"image_picker_version_id\";N;}'),
-('c90pqpkkcu5bc7qeto02ogavf4','C:\\Users\\g3d\\Documents\\Xampp\\tmp','PHPSESSID',1480466241,3601,'__ZF|a:3:{s:14:\"dlayer_session\";a:1:{s:3:\"ENT\";i:1480469841;}s:22:\"dlayer_session_content\";a:1:{s:3:\"ENT\";i:1480469841;}s:23:\"dlayer_session_designer\";a:1:{s:3:\"ENT\";i:1480469841;}}dlayer_session|a:3:{s:11:\"identity_id\";i:1;s:7:\"site_id\";i:1;s:6:\"module\";s:7:\"content\";}dlayer_session_content|a:5:{s:7:\"page_id\";i:2;s:13:\"page_selected\";b:1;s:9:\"column_id\";i:22;s:6:\"row_id\";i:12;s:10:\"content_id\";N;}dlayer_session_designer|a:7:{s:4:\"tool\";a:1:{s:7:\"content\";s:6:\"Column\";}s:3:\"tab\";a:1:{s:7:\"content\";s:6:\"column\";}s:8:\"sub_tool\";a:1:{s:7:\"content\";N;}s:24:\"image_picker_category_id\";N;s:28:\"image_picker_sub_category_id\";N;s:21:\"image_picker_image_id\";N;s:23:\"image_picker_version_id\";N;}'),
-('cio0ou5smeo9fn9g8pb636d3j7','C:\\Users\\g3d\\Documents\\Xampp\\tmp','PHPSESSID',1482270203,3601,'__ZF|a:1:{s:14:\"dlayer_session\";a:1:{s:3:\"ENT\";i:1482273802;}}dlayer_session|a:1:{s:7:\"site_id\";N;}'),
-('e8spf97jr0c5rgpdg41u46qcq6','C:\\Users\\g3d\\Documents\\Xampp\\tmp','PHPSESSID',1479774174,3601,'__ZF|a:3:{s:14:\"dlayer_session\";a:1:{s:3:\"ENT\";i:1479777774;}s:22:\"dlayer_session_content\";a:1:{s:3:\"ENT\";i:1479777774;}s:23:\"dlayer_session_designer\";a:1:{s:3:\"ENT\";i:1479777774;}}dlayer_session|a:3:{s:11:\"identity_id\";i:1;s:7:\"site_id\";i:1;s:6:\"module\";s:7:\"content\";}dlayer_session_content|a:5:{s:7:\"page_id\";i:1;s:13:\"page_selected\";N;s:9:\"column_id\";N;s:6:\"row_id\";N;s:10:\"content_id\";N;}dlayer_session_designer|a:1:{s:4:\"tool\";N;}'),
-('ilgmjfg241oqel9drsfrn3fq87','C:\\Users\\g3d\\Documents\\Xampp\\tmp','PHPSESSID',1479765532,3601,'__ZF|a:1:{s:14:\"dlayer_session\";a:1:{s:3:\"ENT\";i:1479769131;}}'),
-('iuad71eoc9ko9ppr7t6eis1rm4','C:\\Users\\g3d\\Documents\\Xampp\\tmp','PHPSESSID',1479935707,3601,'__ZF|a:1:{s:14:\"dlayer_session\";a:1:{s:3:\"ENT\";i:1479939305;}}'),
-('jus836no9luaa6rbuccj2brcv1','C:\\Users\\g3d\\Documents\\Xampp\\tmp','PHPSESSID',1480542887,3601,'__ZF|a:1:{s:14:\"dlayer_session\";a:1:{s:3:\"ENT\";i:1480546485;}}'),
-('k0i8p00pj8irr6pg4io7orn8p1','C:\\Users\\g3d\\Documents\\Xampp\\tmp','PHPSESSID',1481384761,3601,'__ZF|a:3:{s:14:\"dlayer_session\";a:1:{s:3:\"ENT\";i:1481388361;}s:22:\"dlayer_session_content\";a:1:{s:3:\"ENT\";i:1481388361;}s:23:\"dlayer_session_designer\";a:1:{s:3:\"ENT\";i:1481388361;}}dlayer_session_content|a:5:{s:7:\"page_id\";N;s:13:\"page_selected\";N;s:9:\"column_id\";N;s:6:\"row_id\";N;s:10:\"content_id\";N;}dlayer_session_designer|a:7:{s:4:\"tool\";a:1:{s:7:\"content\";N;}s:3:\"tab\";a:1:{s:7:\"content\";N;}s:8:\"sub_tool\";a:1:{s:7:\"content\";N;}s:24:\"image_picker_category_id\";N;s:28:\"image_picker_sub_category_id\";N;s:21:\"image_picker_image_id\";N;s:23:\"image_picker_version_id\";N;}'),
-('k0tcp8661opittcgqvlj4iag94','C:\\Users\\g3d\\Documents\\Xampp\\tmp','PHPSESSID',1480865106,3601,'__ZF|a:1:{s:14:\"dlayer_session\";a:1:{s:3:\"ENT\";i:1480868705;}}'),
-('l64d863c2vrs0ducfpsu4hi4h3','C:\\Users\\g3d\\Documents\\Xampp\\tmp','PHPSESSID',1479858206,3601,'__ZF|a:1:{s:14:\"dlayer_session\";a:1:{s:3:\"ENT\";i:1479861805;}}'),
-('oat8l3nv1l9heqdk75vt08n963','C:\\Users\\g3d\\Documents\\Xampp\\tmp','PHPSESSID',1480781199,3601,'__ZF|a:1:{s:14:\"dlayer_session\";a:1:{s:3:\"ENT\";i:1480784799;}}dlayer_session|a:2:{s:11:\"identity_id\";i:1;s:7:\"site_id\";i:1;}'),
-('psu6lj9sffplveo7g3vknr28k1','C:\\Users\\g3d\\Documents\\Xampp\\tmp','PHPSESSID',1481381832,3601,'__ZF|a:1:{s:14:\"dlayer_session\";a:1:{s:3:\"ENT\";i:1481385431;}}'),
-('q0vnt0i9pss54hm9o5vnsiroa5','C:\\Users\\g3d\\Documents\\Xampp\\tmp','PHPSESSID',1481067025,3601,'__ZF|a:1:{s:14:\"dlayer_session\";a:1:{s:3:\"ENT\";i:1481070624;}}'),
-('stbugdcar25v9q2gdu4lgjc734','C:\\Users\\g3d\\Documents\\Xampp\\tmp','PHPSESSID',1479862328,3601,'__ZF|a:3:{s:14:\"dlayer_session\";a:1:{s:3:\"ENT\";i:1479865928;}s:22:\"dlayer_session_content\";a:1:{s:3:\"ENT\";i:1479865925;}s:23:\"dlayer_session_designer\";a:1:{s:3:\"ENT\";i:1479865436;}}dlayer_session_content|a:5:{s:7:\"page_id\";i:2;s:13:\"page_selected\";N;s:9:\"column_id\";N;s:6:\"row_id\";N;s:10:\"content_id\";N;}dlayer_session_designer|a:7:{s:4:\"tool\";a:1:{s:7:\"content\";N;}s:3:\"tab\";a:1:{s:7:\"content\";N;}s:8:\"sub_tool\";a:1:{s:7:\"content\";N;}s:24:\"image_picker_category_id\";N;s:28:\"image_picker_sub_category_id\";N;s:21:\"image_picker_image_id\";N;s:23:\"image_picker_version_id\";N;}dlayer_session|a:3:{s:11:\"identity_id\";i:1;s:7:\"site_id\";i:1;s:6:\"module\";s:7:\"content\";}'),
-('ubvv8f467tnttibi0ji03b6u05','C:\\Users\\g3d\\Documents\\Xampp\\tmp','PHPSESSID',1481674395,3601,'__ZF|a:3:{s:14:\"dlayer_session\";a:1:{s:3:\"ENT\";i:1481677994;}s:22:\"dlayer_session_content\";a:1:{s:3:\"ENT\";i:1481677994;}s:23:\"dlayer_session_designer\";a:1:{s:3:\"ENT\";i:1481677994;}}dlayer_session_content|a:5:{s:13:\"page_selected\";N;s:9:\"column_id\";N;s:6:\"row_id\";N;s:10:\"content_id\";N;s:7:\"page_id\";N;}dlayer_session_designer|a:7:{s:24:\"image_picker_category_id\";N;s:28:\"image_picker_sub_category_id\";N;s:21:\"image_picker_image_id\";N;s:23:\"image_picker_version_id\";N;s:4:\"tool\";a:1:{s:7:\"content\";N;}s:8:\"sub_tool\";a:1:{s:7:\"content\";N;}s:3:\"tab\";a:1:{s:7:\"content\";N;}}dlayer_session|a:1:{s:7:\"site_id\";N;}'),
-('ugns0ll377v3qg6kqblgrqulv7','C:\\Users\\g3d\\Documents\\Xampp\\tmp','PHPSESSID',1481069511,3601,'__ZF|a:3:{s:14:\"dlayer_session\";a:1:{s:3:\"ENT\";i:1481073111;}s:22:\"dlayer_session_content\";a:1:{s:3:\"ENT\";i:1481073111;}s:23:\"dlayer_session_designer\";a:1:{s:3:\"ENT\";i:1481073111;}}dlayer_session|a:3:{s:11:\"identity_id\";i:1;s:7:\"site_id\";i:1;s:6:\"module\";s:7:\"content\";}dlayer_session_content|a:5:{s:7:\"page_id\";i:3;s:13:\"page_selected\";b:1;s:9:\"column_id\";i:24;s:6:\"row_id\";i:14;s:10:\"content_id\";i:29;}dlayer_session_designer|a:7:{s:4:\"tool\";a:1:{s:7:\"content\";s:4:\"Text\";}s:3:\"tab\";a:1:{s:7:\"content\";s:10:\"typography\";}s:8:\"sub_tool\";a:1:{s:7:\"content\";s:10:\"Typography\";}s:24:\"image_picker_category_id\";N;s:28:\"image_picker_sub_category_id\";N;s:21:\"image_picker_image_id\";N;s:23:\"image_picker_version_id\";N;}'),
-('v3k9uffauf3k6p55m9pbjgul85','C:\\Users\\g3d\\Documents\\Xampp\\tmp','PHPSESSID',1481143904,3601,'__ZF|a:3:{s:14:\"dlayer_session\";a:1:{s:3:\"ENT\";i:1481147504;}s:22:\"dlayer_session_content\";a:1:{s:3:\"ENT\";i:1481147504;}s:23:\"dlayer_session_designer\";a:1:{s:3:\"ENT\";i:1481147504;}}dlayer_session|a:3:{s:11:\"identity_id\";i:1;s:7:\"site_id\";i:1;s:6:\"module\";s:7:\"content\";}dlayer_session_content|a:5:{s:7:\"page_id\";i:3;s:13:\"page_selected\";b:1;s:9:\"column_id\";i:23;s:6:\"row_id\";i:14;s:10:\"content_id\";i:28;}dlayer_session_designer|a:3:{s:4:\"tool\";a:1:{s:7:\"content\";s:4:\"Text\";}s:3:\"tab\";a:1:{s:7:\"content\";s:10:\"typography\";}s:8:\"sub_tool\";a:1:{s:7:\"content\";s:10:\"Typography\";}}');
+('rurvk3qdusgvdqpk2e96phb5p3','C:\\Users\\g3d\\Documents\\Xampp\\tmp','PHPSESSID',1482515838,3601,'__ZF|a:3:{s:14:\"dlayer_session\";a:1:{s:3:\"ENT\";i:1482519438;}s:22:\"dlayer_session_content\";a:1:{s:3:\"ENT\";i:1482519438;}s:23:\"dlayer_session_designer\";a:1:{s:3:\"ENT\";i:1482519438;}}dlayer_session_content|a:5:{s:13:\"page_selected\";N;s:9:\"column_id\";N;s:6:\"row_id\";N;s:10:\"content_id\";N;s:7:\"page_id\";N;}dlayer_session_designer|a:7:{s:24:\"image_picker_category_id\";N;s:28:\"image_picker_sub_category_id\";N;s:21:\"image_picker_image_id\";N;s:23:\"image_picker_version_id\";N;s:4:\"tool\";a:1:{s:7:\"content\";N;}s:8:\"sub_tool\";a:1:{s:7:\"content\";N;}s:3:\"tab\";a:1:{s:7:\"content\";N;}}dlayer_session|a:1:{s:7:\"site_id\";N;}');
 
 /*Table structure for table `dlayer_setting` */
 
@@ -798,7 +777,7 @@ CREATE TABLE `user_setting_color_history` (
   PRIMARY KEY (`id`),
   KEY `site_id` (`site_id`),
   CONSTRAINT `user_setting_color_history_ibfk_1` FOREIGN KEY (`site_id`) REFERENCES `user_site` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=106 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=108 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `user_setting_color_history` */
 
@@ -896,7 +875,9 @@ insert  into `user_setting_color_history`(`id`,`site_id`,`color_hex`) values
 (101,1,'#eeeeee'),
 (103,1,'#eeeeee'),
 (104,1,'#f0ad4e'),
-(105,1,'#f0ad4e');
+(105,1,'#f0ad4e'),
+(106,1,'#5bc0de'),
+(107,1,'#eeeeee');
 
 /*Table structure for table `user_setting_color_palette` */
 
@@ -988,11 +969,11 @@ insert  into `user_setting_color_palette_color`(`id`,`site_id`,`palette_id`,`col
 (45,4,8,4,'Amber','#f0ad4e'),
 (46,4,8,5,'Red','#d9534f');
 
-/*Table structure for table `user_setting_font_family` */
+/*Table structure for table `user_setting_font_and_text` */
 
-DROP TABLE IF EXISTS `user_setting_font_family`;
+DROP TABLE IF EXISTS `user_setting_font_and_text`;
 
-CREATE TABLE `user_setting_font_family` (
+CREATE TABLE `user_setting_font_and_text` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `site_id` int(11) unsigned NOT NULL,
   `module_id` tinyint(3) unsigned NOT NULL,
@@ -1001,14 +982,14 @@ CREATE TABLE `user_setting_font_family` (
   KEY `site_id` (`site_id`),
   KEY `module_id` (`module_id`),
   KEY `font_family_id` (`font_family_id`),
-  CONSTRAINT `user_setting_font_family_ibfk_1` FOREIGN KEY (`site_id`) REFERENCES `user_site` (`id`),
-  CONSTRAINT `user_setting_font_family_ibfk_2` FOREIGN KEY (`module_id`) REFERENCES `dlayer_module` (`id`),
-  CONSTRAINT `user_setting_font_family_ibfk_3` FOREIGN KEY (`font_family_id`) REFERENCES `designer_css_font_family` (`id`)
+  CONSTRAINT `user_setting_font_and_text_ibfk_1` FOREIGN KEY (`site_id`) REFERENCES `user_site` (`id`),
+  CONSTRAINT `user_setting_font_and_text_ibfk_2` FOREIGN KEY (`module_id`) REFERENCES `dlayer_module` (`id`),
+  CONSTRAINT `user_setting_font_and_text_ibfk_3` FOREIGN KEY (`font_family_id`) REFERENCES `designer_css_font_family` (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=9 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
-/*Data for the table `user_setting_font_family` */
+/*Data for the table `user_setting_font_and_text` */
 
-insert  into `user_setting_font_family`(`id`,`site_id`,`module_id`,`font_family_id`) values 
+insert  into `user_setting_font_and_text`(`id`,`site_id`,`module_id`,`font_family_id`) values 
 (1,1,3,8),
 (2,1,4,1),
 (3,2,3,1),
@@ -1130,12 +1111,13 @@ CREATE TABLE `user_site_content_html` (
   PRIMARY KEY (`id`),
   KEY `site_id` (`site_id`),
   CONSTRAINT `user_site_content_html_ibfk_1` FOREIGN KEY (`site_id`) REFERENCES `user_site` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `user_site_content_html` */
 
 insert  into `user_site_content_html`(`id`,`site_id`,`name`,`content`) values 
-(1,1,'Testing HTML','<h2>Testing the HTML snippet tool</h2>\r\n\r\n<p>The quick brown <strong>fox</strong> jumped <em>over</em> the...</p>\r\n\r\n<ul>\r\n<li>List item one</li>\r\n<li>List item two</li>\r\n</ul>');
+(1,1,'Testing HTML','<h2>Testing the HTML snippet tool</h2>\r\n\r\n<p>The quick brown <strong>fox</strong> jumped <em>over</em> the...</p>\r\n\r\n<ul>\r\n<li>List item one</li>\r\n<li>List item two</li>\r\n</ul>'),
+(2,1,'Custom','<p>Testing</p>\r\n\r\n<ul>\r\n<li>Item 1</li>\r\n<li>Item 2</li>\r\n</ul>');
 
 /*Table structure for table `user_site_content_jumbotron` */
 
@@ -1756,12 +1738,13 @@ CREATE TABLE `user_site_page_content_item_html` (
   CONSTRAINT `user_site_page_content_item_html_ibfk_2` FOREIGN KEY (`page_id`) REFERENCES `user_site_page` (`id`),
   CONSTRAINT `user_site_page_content_item_html_ibfk_3` FOREIGN KEY (`content_id`) REFERENCES `user_site_page_structure_content` (`id`),
   CONSTRAINT `user_site_page_content_item_html_ibfk_4` FOREIGN KEY (`data_id`) REFERENCES `user_site_content_html` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `user_site_page_content_item_html` */
 
 insert  into `user_site_page_content_item_html`(`id`,`site_id`,`page_id`,`content_id`,`data_id`) values 
-(1,1,2,26,1);
+(1,1,2,26,1),
+(2,1,3,33,2);
 
 /*Table structure for table `user_site_page_content_item_image` */
 
@@ -1899,7 +1882,7 @@ CREATE TABLE `user_site_page_structure_column` (
   CONSTRAINT `user_site_page_structure_column_ibfk_1` FOREIGN KEY (`site_id`) REFERENCES `user_site` (`id`),
   CONSTRAINT `user_site_page_structure_column_ibfk_2` FOREIGN KEY (`row_id`) REFERENCES `user_site_page_structure_row` (`id`),
   CONSTRAINT `user_site_page_structure_column_ibfk_3` FOREIGN KEY (`page_id`) REFERENCES `user_site_page` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=30 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=32 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `user_site_page_structure_column` */
 
@@ -1925,7 +1908,9 @@ insert  into `user_site_page_structure_column`(`id`,`site_id`,`page_id`,`row_id`
 (26,1,3,13,12,'md',0,1),
 (27,1,3,15,6,'md',0,1),
 (28,1,3,15,6,'md',0,2),
-(29,1,2,8,12,'md',0,3);
+(29,1,2,8,12,'md',0,3),
+(30,1,3,16,6,'md',0,1),
+(31,1,3,16,6,'md',0,2);
 
 /*Table structure for table `user_site_page_structure_content` */
 
@@ -1948,7 +1933,7 @@ CREATE TABLE `user_site_page_structure_content` (
   CONSTRAINT `user_site_page_structure_content_ibfk_2` FOREIGN KEY (`page_id`) REFERENCES `user_site_page` (`id`),
   CONSTRAINT `user_site_page_structure_content_ibfk_4` FOREIGN KEY (`content_type`) REFERENCES `designer_content_type` (`id`),
   CONSTRAINT `user_site_page_structure_content_ibfk_5` FOREIGN KEY (`column_id`) REFERENCES `user_site_page_structure_column` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=33 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=34 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `user_site_page_structure_content` */
 
@@ -1981,7 +1966,8 @@ insert  into `user_site_page_structure_content`(`id`,`site_id`,`page_id`,`column
 (29,1,3,24,1,1),
 (30,1,3,25,1,1),
 (31,1,3,27,5,1),
-(32,1,3,28,4,1);
+(32,1,3,28,4,1),
+(33,1,3,30,7,1);
 
 /*Table structure for table `user_site_page_structure_row` */
 
@@ -2000,7 +1986,7 @@ CREATE TABLE `user_site_page_structure_row` (
   KEY `sort_order` (`sort_order`),
   CONSTRAINT `user_site_page_structure_row_ibfk_1` FOREIGN KEY (`site_id`) REFERENCES `user_site` (`id`),
   CONSTRAINT `user_site_page_structure_row_ibfk_2` FOREIGN KEY (`page_id`) REFERENCES `user_site_page` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=16 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=17 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `user_site_page_structure_row` */
 
@@ -2014,9 +2000,10 @@ insert  into `user_site_page_structure_row`(`id`,`site_id`,`page_id`,`column_id`
 (10,1,1,0,4),
 (11,1,1,0,5),
 (12,1,2,0,4),
-(13,1,3,0,1),
-(14,1,3,0,2),
-(15,1,3,0,3);
+(13,1,3,0,2),
+(14,1,3,0,3),
+(15,1,3,0,1),
+(16,1,3,0,4);
 
 /*Table structure for table `user_site_page_styling_column_background_color` */
 
@@ -2063,7 +2050,7 @@ CREATE TABLE `user_site_page_styling_content_item_background_color` (
   CONSTRAINT `user_site_page_styling_content_item_background_color_ibfk_1` FOREIGN KEY (`site_id`) REFERENCES `user_site` (`id`),
   CONSTRAINT `user_site_page_styling_content_item_background_color_ibfk_2` FOREIGN KEY (`page_id`) REFERENCES `user_site_page` (`id`),
   CONSTRAINT `user_site_page_styling_content_item_background_color_ibfk_3` FOREIGN KEY (`content_id`) REFERENCES `user_site_page_structure_content` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=10 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=11 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `user_site_page_styling_content_item_background_color` */
 
@@ -2075,7 +2062,8 @@ insert  into `user_site_page_styling_content_item_background_color`(`id`,`site_i
 (6,1,2,17,'#eeeeee'),
 (7,1,2,22,'#5bc0de'),
 (8,1,2,26,'#f0ad4e'),
-(9,1,3,28,'');
+(9,1,3,28,''),
+(10,1,3,33,'#5bc0de');
 
 /*Table structure for table `user_site_page_styling_content_item_typography` */
 
@@ -2096,13 +2084,14 @@ CREATE TABLE `user_site_page_styling_content_item_typography` (
   CONSTRAINT `user_site_page_styling_content_item_typography_ibfk_2` FOREIGN KEY (`page_id`) REFERENCES `user_site_page` (`id`),
   CONSTRAINT `user_site_page_styling_content_item_typography_ibfk_3` FOREIGN KEY (`content_id`) REFERENCES `user_site_page_structure_content` (`id`),
   CONSTRAINT `user_site_page_styling_content_item_typography_ibfk_4` FOREIGN KEY (`font_family_id`) REFERENCES `designer_css_font_family` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 /*Data for the table `user_site_page_styling_content_item_typography` */
 
 insert  into `user_site_page_styling_content_item_typography`(`id`,`site_id`,`page_id`,`content_id`,`font_family_id`) values 
 (2,1,3,28,2),
-(3,1,3,31,5);
+(3,1,3,31,5),
+(4,1,2,16,5);
 
 /*Table structure for table `user_site_page_styling_page_background_color` */
 


### PR DESCRIPTION
- Text weight can now be set in the styling sub tool for text content items [Feature]
- Simplified the models for typography tool, one query when possible for all values
- Initial work on moved towards shared tool models
- Values only saved when necessary, previously the add code was saving values which matched the defaults for the module.