### PR TITLE
Control bar action helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ v1.12: In Progress
 - The re-order code which runs after an element is deleted in the Form Builder was sorting incorrectly. [Bugfix]
 - Added an admin controller to the Content Manager. [Refactoring]
 - Added an admin controller to the default module. [Refactoring]
+- Added the control bar to the Form Builder and Content Manager previews. There is a button to return to the Designer/Manager and in the Form Builder an option to set the width of the preview. [Feature]
+- The Form Builder displays the assigned title and subtitle. [Bugfix]
 - Model cleanup. [Refactoring]
 - Minor fixes and improvements.
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ Dlayer
 
 Thank you for taking the time to look at Dlayer, I've been working on this project for many years including the inevitable restarts, it has taken an inordinate amount of work to finally get here, now that I have a stable base I'm hoping to grow the project.
 
-Over the next few weeks, I am going to continue to polish the core of the Content manager, work on the set-up process and then start reintegrating the removed designers, first on the list is the Form builder.
+I am working towards reinstating the Website Manager and the Media Library. As soon as they are back into the app, I can move towards making Dlayer create a website and then its main selling point, widgets.
 
 Latest stable release 
 --------
-v1.11 - Released 10th February 2017
+v1.12 - Released 14th February 2017
  
 Overview
 --------
@@ -36,12 +36,12 @@ Requirements
 Documentation 
 ---------
 
-Please check the documentation at http://www.dlayer.com/docs/ the documentation is currently a little sparse, I am in the progress of moving it to http://dlayer.github.io/dlayer/
+Please check the documentation at http://www.dlayer.com/docs/ - the documentation is currently a little sparse, I am in the progress of moving it to http://dlayer.github.io/dlayer/
 
 Setup
 ---------
 
-I am working towards improving the set-up/reset process for Dlayer, until then please follow the steps below.
+I am working towards improving the set-up/reset process for Dlayer, until then, please follow the steps below.
 
 * Set-up your development environment. I have written a blog post on setting up a suitable environment on a Linux machine, http://www.deanblackborough.com/2016/04/30/ubuntu-install-apache-php-mysql-sass-bower-and-phpstorm-for-local-development/
 * I will assume your local environment is at http://dlayer.dev

--- a/application/configs/environment.php
+++ b/application/configs/environment.php
@@ -10,8 +10,8 @@
 * production, development, testing or staging
 */
 
-$environment = 'production';
-//$environment = 'development';
+//$environment = 'production';
+$environment = 'development';
 
 // Version number for current release
 $version_no = 'v1.12';

--- a/application/configs/environment.php
+++ b/application/configs/environment.php
@@ -10,10 +10,10 @@
 * production, development, testing or staging
 */
 
-//$environment = 'production';
-$environment = 'development';
+$environment = 'production';
+//$environment = 'development';
 
 // Version number for current release
 $version_no = 'v1.12';
 // Release date for current release
-$version_release_date = 'In progress';
+$version_release_date = '14th February 2017';

--- a/application/modules/content/controllers/AdminController.php
+++ b/application/modules/content/controllers/AdminController.php
@@ -146,7 +146,7 @@ class Content_AdminController extends Zend_Controller_Action
             )
         );
 
-        $this->assignToControlBar($control_bar_buttons, $control_bar_drops);
+        $this->_helper->populateControlBar($control_bar_buttons, $control_bar_drops);
     }
 
     /**
@@ -193,22 +193,5 @@ class Content_AdminController extends Zend_Controller_Action
                 $this->redirect('/content');
             }
         }
-    }
-
-    /**
-     * Assign control bar buttons
-     *
-     * @param array $buttons
-     * @param array $drops
-     *
-     * @todo Move this into an action helper
-     * @return void
-     */
-    private function assignToControlBar(array $buttons, array $drops)
-    {
-        $layout = Zend_Layout::getMvcInstance();
-        $layout->assign('show_control_bar', true);
-        $layout->assign('control_bar_buttons', $buttons);
-        $layout->assign('control_bar_drops', $drops);
     }
 }

--- a/application/modules/content/controllers/DesignController.php
+++ b/application/modules/content/controllers/DesignController.php
@@ -392,6 +392,16 @@ class Content_DesignController extends Zend_Controller_Action
         $this->view->styling_rows = $designer_page->rowStyles();
         $this->view->styling_page = $designer_page->pageStyles();
 
+        $control_bar_buttons = array(
+            array(
+                'uri' => '/content/design/index',
+                'class' => 'primary',
+                'name' => 'Return to Content Manager'
+            )
+        );
+
+        $this->_helper->populateControlBar($control_bar_buttons, array());
+
         return $this->view->render("design/page-preview.phtml");
     }
 

--- a/application/modules/content/controllers/IndexController.php
+++ b/application/modules/content/controllers/IndexController.php
@@ -118,24 +118,7 @@ class Content_IndexController extends Zend_Controller_Action
             )
         );
 
-        $this->assignToControlBar($control_bar_buttons, $control_bar_drops);
-    }
-
-    /**
-     * Assign control bar buttons
-     *
-     * @param array $buttons
-     * @param array $drops
-     *
-     * @todo Move this into an action helper
-     * @return void
-     */
-    private function assignToControlBar(array $buttons, array $drops)
-    {
-        $layout = Zend_Layout::getMvcInstance();
-        $layout->assign('show_control_bar', true);
-        $layout->assign('control_bar_buttons', $buttons);
-        $layout->assign('control_bar_drops', $drops);
+        $this->_helper->populateControlBar($control_bar_buttons, $control_bar_drops);
     }
 
     /**

--- a/application/modules/dlayer/controllers/AdminController.php
+++ b/application/modules/dlayer/controllers/AdminController.php
@@ -88,7 +88,7 @@ class Dlayer_AdminController extends Zend_Controller_Action
             )
         );
 
-        $this->assignToControlBar($control_bar_buttons, $control_bar_drops);
+        $this->_helper->populateControlBar($control_bar_buttons, $control_bar_drops);
     }
 
     /**
@@ -179,22 +179,5 @@ class Dlayer_AdminController extends Zend_Controller_Action
                 $this->redirect('/dlayer/index/home');
             }
         }
-    }
-
-    /**
-     * Assign control bar buttons
-     *
-     * @param array $buttons
-     * @param array $drops
-     *
-     * @todo Move this into an action helper
-     * @return void
-     */
-    private function assignToControlBar(array $buttons, array $drops)
-    {
-        $layout = Zend_Layout::getMvcInstance();
-        $layout->assign('show_control_bar', true);
-        $layout->assign('control_bar_buttons', $buttons);
-        $layout->assign('control_bar_drops', $drops);
     }
 }

--- a/application/modules/dlayer/controllers/IndexController.php
+++ b/application/modules/dlayer/controllers/IndexController.php
@@ -169,24 +169,7 @@ class Dlayer_IndexController extends Zend_Controller_Action
             )
         );
 
-        $this->assignToControlBar($control_bar_buttons, $control_bar_drops);
-    }
-
-    /**
-     * Assign control bar buttons
-     *
-     * @param array $buttons
-     * @param array $drops
-     *
-     * @todo Move this into an action helper
-     * @return void
-     */
-    private function assignToControlBar(array $buttons, array $drops)
-    {
-        $layout = Zend_Layout::getMvcInstance();
-        $layout->assign('show_control_bar', true);
-        $layout->assign('control_bar_buttons', $buttons);
-        $layout->assign('control_bar_drops', $drops);
+        $this->_helper->populateControlBar($control_bar_buttons, $control_bar_drops);
     }
 
     /**

--- a/application/modules/dlayer/views/scripts/index/index.phtml
+++ b/application/modules/dlayer/views/scripts/index/index.phtml
@@ -31,7 +31,7 @@
 	</div>
 
     <div class="col-md-6 col-sm-6 col-xs-12">
-        <h3><span class="label label-success">v1.12</span> Not yet named <small class="text-muted">(In progress)</small></h3>
+        <h3><span class="label label-success">v1.12</span> Mixed bag <small class="text-muted">(14th February 2017)</small></h3>
 
         <ul>
             <li>Added a delete sub tool to each of the content items. [Feature]</li>
@@ -39,6 +39,8 @@
             <li>The re-order code which runs after an element is deleted in the Form Builder was sorting incorrectly. [Bugfix]</li>
             <li>Added an admin controller to the Content Manager. [Refactoring]</li>
             <li>Added an admin controller to the default module. [Refactoring]</li>
+            <li>Added the control bar to the Form Builder and Content Manager previews. There is a button to return to the Designer/Manager and in the Form Builder an option to set the width of the preview. [Feature]</li>
+            <li>The Form Builder displays the assigned title and subtitle. [Bugfix]</li>
             <li>Model cleanup. [Refactoring]</li>
             <li>Minor fixes and improvements.</li>
         </ul>

--- a/application/modules/form/controllers/AdminController.php
+++ b/application/modules/form/controllers/AdminController.php
@@ -224,23 +224,6 @@ class Form_AdminController extends Zend_Controller_Action
             )
         );
 
-        $this->assignToControlBar($control_bar_buttons, $control_bar_drops);
-    }
-
-    /**
-     * Assign control bar buttons
-     *
-     * @param array $buttons
-     * @param array $drops
-     *
-     * @todo Move this into an action helper
-     * @return void
-     */
-    private function assignToControlBar(array $buttons, array $drops)
-    {
-        $layout = Zend_Layout::getMvcInstance();
-        $layout->assign('show_control_bar', true);
-        $layout->assign('control_bar_buttons', $buttons);
-        $layout->assign('control_bar_drops', $drops);
+        $this->_helper->populateControlBar($control_bar_buttons, $control_bar_drops);
     }
 }

--- a/application/modules/form/controllers/DesignController.php
+++ b/application/modules/form/controllers/DesignController.php
@@ -103,7 +103,7 @@ class Form_DesignController extends Zend_Controller_Action
 
         $this->controlBar();
 
-        $this->view->form = $this->form();
+        $this->view->design_html = $this->form();
         $this->view->ribbon = $this->ribbon();
 
         $this->view->module = $this->getRequest()->getModuleName();
@@ -134,11 +134,15 @@ class Form_DesignController extends Zend_Controller_Action
     {
         $this->_helper->setLayout('preview');
 
-        $this->view->form = $this->formPreview();
+        $this->view->html = $this->formPreview();
 
         $layout = Zend_Layout::getMvcInstance();
         $layout->assign('css_include', array('css/dlayer.css'));
-        $layout->assign('js_include', array());
+        $layout->assign('js_include',
+            array(
+                'scripts/form-builder.js'
+            )
+        );
         $layout->assign('title', 'Dlayer.com - Form preview');
     }
 
@@ -266,6 +270,7 @@ class Form_DesignController extends Zend_Controller_Action
     {
         $form = new Dlayer_Designer_Form($this->site_id, $this->form_id);
 
+        $this->view->layout_options = $form->layoutOptions();
         $this->view->form = $form->form();
         $this->view->row_styling = $form->rowStyles();
 
@@ -279,7 +284,7 @@ class Form_DesignController extends Zend_Controller_Action
 
         $this->_helper->populateControlBar($control_bar_buttons, array());
 
-        return $this->view->render("design/preview.phtml");
+        return $this->view->render("design/form-preview.phtml");
     }
 
     /**

--- a/application/modules/form/controllers/DesignController.php
+++ b/application/modules/form/controllers/DesignController.php
@@ -282,6 +282,9 @@ class Form_DesignController extends Zend_Controller_Action
             )
         );
 
+        $layout = Zend_Layout::getMvcInstance();
+        $layout->assign('preview_at', true);
+
         $this->_helper->populateControlBar($control_bar_buttons, array());
 
         return $this->view->render("design/form-preview.phtml");

--- a/application/modules/form/controllers/DesignController.php
+++ b/application/modules/form/controllers/DesignController.php
@@ -269,6 +269,16 @@ class Form_DesignController extends Zend_Controller_Action
         $this->view->form = $form->form();
         $this->view->row_styling = $form->rowStyles();
 
+        $control_bar_buttons = array(
+            array(
+                'uri' => '/form/design/index',
+                'class' => 'primary',
+                'name' => 'Return to Form Builder'
+            )
+        );
+
+        $this->_helper->populateControlBar($control_bar_buttons, array());
+
         return $this->view->render("design/preview.phtml");
     }
 

--- a/application/modules/form/controllers/IndexController.php
+++ b/application/modules/form/controllers/IndexController.php
@@ -117,23 +117,6 @@ class Form_IndexController extends Zend_Controller_Action
             )
         );
 
-        $this->assignToControlBar($control_bar_buttons, $control_bar_drops);
-    }
-
-    /**
-     * Assign control bar buttons
-     *
-     * @param array $buttons
-     * @param array $drops
-     *
-     * @todo Move this into an action helper
-     * @return void
-     */
-    private function assignToControlBar(array $buttons, array $drops)
-    {
-        $layout = Zend_Layout::getMvcInstance();
-        $layout->assign('show_control_bar', true);
-        $layout->assign('control_bar_buttons', $buttons);
-        $layout->assign('control_bar_drops', $drops);
+        $this->_helper->populateControlBar($control_bar_buttons, $control_bar_drops);
     }
 }

--- a/application/modules/form/views/scripts/design/form-preview.phtml
+++ b/application/modules/form/views/scripts/design/form-preview.phtml
@@ -1,3 +1,5 @@
 <?php /** @var $this Dlayer_View_Codehinting */?>
 
+<h2><?php echo $this->escape($this->layout_options['title']); ?>
+    <?php if (strlen($this->layout_options['subtitle']) > 0) { echo ' <small>' . $this->escape($this->layout_options['subtitle'])  . '</small>'; } ?></h2>
 <?php echo $this->form; ?>

--- a/application/modules/form/views/scripts/design/index.phtml
+++ b/application/modules/form/views/scripts/design/index.phtml
@@ -3,7 +3,7 @@
 <div id="designer">
     <div class="row">
         <div class="col-lg-9 design">
-            <?php echo $this->form; ?>
+            <?php echo $this->design_html; ?>
         </div>
         <div class="col-lg-3">
             <div class="row">

--- a/application/modules/form/views/scripts/design/preview.phtml
+++ b/application/modules/form/views/scripts/design/preview.phtml
@@ -14,8 +14,15 @@
 
 <div class="container">
     <div class="row">
-        <div class="col-md-12">
-            <?php echo $this->form; ?>
+        <div class="col-md-12 preview-form">
+            <?php echo $this->html; ?>
         </div>
     </div>
 </div>
+
+<script>
+    $(document).ready(function()
+    {
+        formBuilder.setPreviewAtWidth();
+    });
+</script>

--- a/application/views/layouts/layout.phtml
+++ b/application/views/layouts/layout.phtml
@@ -67,6 +67,6 @@
 	            <?php } ?>
             </div>
         </nav>
-	<?php } ?>
+	    <?php } ?>
 	</body>
 </html>

--- a/application/views/layouts/preview.phtml
+++ b/application/views/layouts/preview.phtml
@@ -58,6 +58,16 @@
                             </ul>
                         </div>
                     <?php } ?>
+                    <div class="btn-group dropup">
+                        <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                            Preview @ <span class="caret"></span></button>
+                        <ul class="dropdown-menu">
+                            <li><a href="#" class="preview_at" data-cols="12">Full width</a></li>
+                            <li><a href="#" class="preview_at" data-cols="9">Three quarter width</a></li>
+                            <li><a href="#" class="preview_at" data-cols="6">Half width</a></li>
+                            <li><a href="#" class="preview_at" data-cols="3">Quarter width</a></li>
+                        </ul>
+                    </div>
                 </div>
             </nav>
         <?php } ?>

--- a/application/views/layouts/preview.phtml
+++ b/application/views/layouts/preview.phtml
@@ -58,6 +58,7 @@
                             </ul>
                         </div>
                     <?php } ?>
+                    <?php if ($this->layout()->preview_at === true) { ?>
                     <div class="btn-group dropup">
                         <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                             Preview @ <span class="caret"></span></button>
@@ -68,6 +69,7 @@
                             <li><a href="#" class="preview_at" data-cols="3">Quarter width</a></li>
                         </ul>
                     </div>
+                    <?php } ?>
                 </div>
             </nav>
         <?php } ?>

--- a/application/views/layouts/preview.phtml
+++ b/application/views/layouts/preview.phtml
@@ -41,5 +41,25 @@
 	</head>
 	<body>
 		<?php echo $this->layout()->content; ?>
+        <?php if ($this->layout()->show_control_bar === true) { ?>
+            <nav class="navbar navbar-default navbar-fixed-bottom">
+                <div class="container">
+                    <?php foreach ($this->layout()->control_bar_buttons as $button) { ?>
+                        <a href="<?php echo $this->escape($button['uri']); ?>" class="navbar-btn btn btn-<?php echo $this->escape($button['class']); ?>"><?php echo $this->escape($button['name']); ?></a>
+                    <?php } ?>
+                    <?php foreach ($this->layout()->control_bar_drops as $drop) { ?>
+                        <div class="btn-group dropup">
+                            <button type="button" class="btn btn-<?php echo $this->escape($drop['class']); ?> dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                <?php echo $this->escape($drop['name']); ?> <span class="caret"></span></button>
+                            <ul class="dropdown-menu">
+                                <?php foreach ($drop['buttons'] as $button) { ?>
+                                    <li><a href="<?php echo $this->escape($button['uri']); ?>"><?php echo $this->escape($button['name']); ?></a></li>
+                                <?php } ?>
+                            </ul>
+                        </div>
+                    <?php } ?>
+                </div>
+            </nav>
+        <?php } ?>
 	</body>
 </html>

--- a/library/Dlayer/Action/CodeHinting.php
+++ b/library/Dlayer/Action/CodeHinting.php
@@ -100,4 +100,15 @@ class Dlayer_Action_CodeHinting extends Zend_Controller_Action_Helper_Abstract
 		array $js_includes, $title, $preview_uri = '', $signed_in = TRUE)
 	{
 	}
+
+    /**
+     * Pass the control bar options to the layout
+     *
+     * @param array $buttons Buttons for control bar
+     * @param array $dropdowns Drop down data array for control bar
+     * @return Dlayer_Action_PopulateControlBar
+     */
+    public function populateControlBar(array $buttons, array $dropdowns)
+    {
+    }
 }

--- a/library/Dlayer/Action/PopulateControlBar.php
+++ b/library/Dlayer/Action/PopulateControlBar.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Pass the control bar options to the layout
+ *
+ * @author Dean Blackborough
+ * @copyright G3D Development Limited
+ * @license https://github.com/Dlayer/dlayer/blob/master/LICENSE
+ */
+class Dlayer_Action_PopulateControlBar extends Zend_Controller_Action_Helper_Abstract
+{
+    /**
+     * Sey layout properties
+     *
+     * @param array $buttons Buttons for control bar
+     * @param array $dropdowns Drop down data array for control bar
+     * @return void
+     */
+    function direct(array $buttons, array $dropdowns)
+    {
+        $layout = Zend_Layout::getMvcInstance();
+        $layout->assign('show_control_bar', true);
+        $layout->assign('control_bar_buttons', $buttons);
+        $layout->assign('control_bar_drops', $dropdowns);
+    }
+}

--- a/library/Dlayer/DesignerTool/FormBuilder/Password/Form.php
+++ b/library/Dlayer/DesignerTool/FormBuilder/Password/Form.php
@@ -85,25 +85,6 @@ class Dlayer_DesignerTool_FormBuilder_Password_Form extends Dlayer_Form_Tool_For
 
         $this->elements['description'] = $description;
 
-        $placeholder = new Zend_Form_Element_Text('placeholder');
-        $placeholder->setLabel('Placeholder');
-        $placeholder->setAttribs(
-            array(
-                'maxlength'=>255,
-                'placeholder'=>'e.g., ********',
-                'class'=>'form-control input-sm'
-            )
-        );
-        $placeholder->setDescription('Please enter the text which appears inside the element when it is empty, typically 
-            this will be an example of expected input');
-        $placeholder->setBelongsTo('params');
-
-        if (array_key_exists('placeholder', $this->data) && $this->data['placeholder'] !== false) {
-            $placeholder->setValue($this->data['placeholder']);
-        }
-
-        $this->elements['placeholder'] = $placeholder;
-
         $size = new Zend_Form_Element_Hidden('size');
         $size->setBelongsTo('params');
         $size->setValue(50);

--- a/library/Dlayer/DesignerTool/FormBuilder/Password/Ribbon.php
+++ b/library/Dlayer/DesignerTool/FormBuilder/Password/Ribbon.php
@@ -44,7 +44,6 @@ class Dlayer_DesignerTool_FormBuilder_Password_Ribbon extends Dlayer_Ribbon_Form
             $this->field_data = array(
                 'label' => false,
                 'description' => false,
-                'placeholder' => false,
                 'size' => false,
                 'maxlength' => false
             );
@@ -86,15 +85,6 @@ class Dlayer_DesignerTool_FormBuilder_Password_Ribbon extends Dlayer_Ribbon_Form
             $this->fieldData();
 
             $this->preview_data = array(
-                'attribute_values' => array(
-                    array(
-                        'element' => '#params-placeholder',
-                        'field_id' => $this->tool['field_id'],
-                        'attribute' => 'placeholder',
-                        'initial_value' => $this->field_data['placeholder'],
-                        'optional' => true
-                    )
-                ),
                 'element_values' => array(
                     array(
                         'element' => '#params-label',

--- a/library/Dlayer/DesignerTool/FormBuilder/Password/Tool.php
+++ b/library/Dlayer/DesignerTool/FormBuilder/Password/Tool.php
@@ -20,7 +20,6 @@ class Dlayer_DesignerTool_FormBuilder_Password_Tool extends Dlayer_DesignerTool_
         $valid = false;
         if (array_key_exists('label', $params) === true &&
             array_key_exists('description', $params) === true &&
-            array_key_exists('placeholder', $params) === true &&
             array_key_exists('size', $params) === true &&
             array_key_exists('maxlength', $params) === true) {
 
@@ -41,7 +40,6 @@ class Dlayer_DesignerTool_FormBuilder_Password_Tool extends Dlayer_DesignerTool_
         $valid = false;
         if (strlen(trim($params['label'])) > 0 &&
             strlen(trim($params['description'])) >= 0 &&
-            strlen(trim($params['placeholder'])) >= 0 &&
             intval($params['size']) > 0 &&
             intval($params['maxlength']) > 0) {
 
@@ -63,7 +61,6 @@ class Dlayer_DesignerTool_FormBuilder_Password_Tool extends Dlayer_DesignerTool_
         $this->params = array(
             'label' => trim($params['label']),
             'description' => trim($params['description']),
-            'placeholder' => trim($params['placeholder']),
             'size' => intval($params['size']),
             'maxlength' => intval($params['maxlength'])
         );

--- a/library/Dlayer/DesignerTool/FormBuilder/Password/scripts/password.phtml
+++ b/library/Dlayer/DesignerTool/FormBuilder/Password/scripts/password.phtml
@@ -3,15 +3,6 @@
 <?php if ($this->edit_mode === true) { ?>
     <script>
         <?php
-        foreach ($this->data['preview']['attribute_values'] as $attribute) {
-            echo "previewFormBuilder.attributeValue('" . $this->escape($attribute['element']) . "', '";
-            echo $this->escape($attribute['field_id']) . "', '";
-            echo $this->escape($attribute['attribute']) . "', '";
-            echo $this->escape($attribute['initial_value']) . "', ";
-            echo ($attribute['optional'] === true) ? 'true' : 'false';
-            echo ");" . PHP_EOL;
-        }
-
         foreach ($this->data['preview']['element_values'] as $attribute) {
             echo "previewFormBuilder.elementValue('" . $this->escape($attribute['element']) . "', '";
             echo $this->escape($attribute['field_id']) . "', '";

--- a/library/Dlayer/DesignerTool/FormBuilder/Shared/Model/Element.php
+++ b/library/Dlayer/DesignerTool/FormBuilder/Shared/Model/Element.php
@@ -111,6 +111,33 @@ class Dlayer_DesignerTool_FormBuilder_Shared_Model_Element extends Zend_Db_Table
     }
 
     /**
+     * Delete the form field
+     *
+     * @param integer $site_id
+     * @param integer $form_id
+     * @param integer $id
+     *
+     * @return boolean
+     */
+    public function deleteField($site_id, $form_id, $id)
+    {
+        $sql = "DELETE FROM 
+                    `user_site_form_field` 
+                WHERE 
+                    `site_id` = :site_id AND 
+                    `form_id` = :form_id AND 
+                    `id` = :field_id 
+                LIMIT 
+                    1";
+        $stmt = $this->_db->prepare($sql);
+        $stmt->bindValue(':site_id', $site_id, PDO::PARAM_INT);
+        $stmt->bindValue(':form_id', $form_id, PDO::PARAM_INT);
+        $stmt->bindValue(':field_id', $id, PDO::PARAM_INT);
+
+        return $stmt->execute();
+    }
+
+    /**
      * Calculate the sort order for the new form field
      *
      * @param integer $site_id

--- a/library/Dlayer/DesignerTool/FormBuilder/Shared/Tool/Element.php
+++ b/library/Dlayer/DesignerTool/FormBuilder/Shared/Tool/Element.php
@@ -23,6 +23,11 @@ abstract class Dlayer_DesignerTool_FormBuilder_Shared_Tool_Element extends Dlaye
 
         if ($field_id !== false) {
             $continue = $model->addAttributes($this->site_id, $this->form_id, $field_id, $this->params, $this->field_type);
+
+            // Remove field if attributes not added
+            if ($continue === false) {
+                $model->deleteField($this->site_id, $this->form_id, $field_id);
+            }
         }
 
         if ($field_id !== false && $continue === true) {

--- a/library/Dlayer/View/Bootstrap3NavbarDlayer.php
+++ b/library/Dlayer/View/Bootstrap3NavbarDlayer.php
@@ -235,7 +235,7 @@ class Dlayer_View_Bootstrap3NavbarDlayer extends Zend_View_Helper_Abstract
 	{
 		$html = '<p class="navbar-text navbar-inverse navbar-right">';
 		$html .= '<span class="glyphicon glyphicon-new-window" aria-hidden="true"></span> <a href="' .
-			$this->preview_uri . '" class="navbar-link" target="_blank" title="Preview">Preview</a>';
+			$this->preview_uri . '" class="navbar-link" title="Preview">Preview</a>';
 		$html .= '</p>';
 
 		return $html;

--- a/library/Dlayer/View/ContentPagePreview.php
+++ b/library/Dlayer/View/ContentPagePreview.php
@@ -71,7 +71,7 @@ class Dlayer_View_ContentPagePreview extends Zend_View_Helper_Abstract
      *
      * @param array $responsive_column_widths
      *
-     * @return Dlayer_View_ContentPage
+     * @return Dlayer_View_ContentPagePreview
      */
     public function setResponsiveOptions(array $responsive_column_widths)
     {
@@ -90,7 +90,7 @@ class Dlayer_View_ContentPagePreview extends Zend_View_Helper_Abstract
 	{
 		$this->view->rowPreview()->setColumnId(0);
 
-		$this->html = '<div class="container" ' . $this->view->stylingPage()->setPage($this->page_id) . '>';
+		$this->html = '<div class="preview-page container" ' . $this->view->stylingPage()->setPage($this->page_id) . '>';
 		$this->html .= $this->view->rowPreview()->render();
 		$this->html .= '</div>';
 

--- a/private/database/tables/data/designer_form_field_attribute.sql
+++ b/private/database/tables/data/designer_form_field_attribute.sql
@@ -8,7 +8,6 @@ insert  into `designer_form_field_attribute`(`id`,`field_type_id`,`name`,`attrib
     (6,3,'Max length','maxlength',1),
     (7,1,'Placeholder','placeholder',2),
     (8,2,'Placeholder','placeholder',2),
-    (9,3,'Placeholder','placeholder',2),
     (10,4,'Size','size',1),
     (11,4,'Max length','maxlength',1),
     (12,4,'Placeholder','placeholder',2),

--- a/public/scripts/form-builder.js
+++ b/public/scripts/form-builder.js
@@ -110,9 +110,7 @@ var formBuilder =
          * Set preview width
          */
         setPreviewAtWidth: function() {
-            console.log('loaded');
             $('.preview_at').click(function() {
-                console.log('hghghghg');
                  $('div.preview-form').removeClass('col-md-12 col-md-9 col-md-6 col-md-3').addClass('col-md-' + $(this).data('cols'));
             });
         }


### PR DESCRIPTION
- Added control bar to Form Builder and Content Manager previews.
- The Form Builder preview shows the assigned title for the form.
- Added a 'preview @' control to allowing viewing of Form Builder preview at different widths.
- Remove newly added field if there is an error adding field attributes
- Added an action helper which assigns control bar data to layout, removes controller duplication